### PR TITLE
Add moderation module with MongoDB ban tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Shroomiess Bot
+
+Discord bot with moderation features.
+
+## Configuration
+
+Create a `.env` file with the following values:
+
+```
+DISCORD_BOT_TOKEN=your_bot_token
+MONGODB_URI=your_mongodb_connection_string
+```
+
+The bot connects to MongoDB to store active bans.
+
+## Commands
+
+- `!ping` – basic ping.
+- `!ban @user [reason]` – bans the mentioned user and records the ban in the database.
+- `!unban <userId>` – removes a ban and unbans the user by ID.
+
+The bot re-applies active bans from the database on startup.
+
+## Running
+
+Install dependencies and start the bot:
+
+```
+npm install
+npm start
+```

--- a/bot.js
+++ b/bot.js
@@ -1,6 +1,21 @@
 require('dotenv').config();
 const { Client, GatewayIntentBits, Collection, Partials } = require('discord.js');
-const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const db = require('./database');
+
+// Dynamically load features
+const features = {};
+const featuresPath = path.join(__dirname, 'features');
+if (fs.existsSync(featuresPath)) {
+  for (const file of fs.readdirSync(featuresPath)) {
+    if (file.endsWith('.js')) {
+      const name = path.basename(file, '.js');
+      features[name] = require(path.join(featuresPath, file));
+    }
+  }
+}
+const moderation = features.moderation;
 
 // Create Discord client with desired intents
 const client = new Client({
@@ -13,16 +28,58 @@ const client = new Client({
 });
 
 client.commands = new Collection();
+client.features = features;
 
-// Example command handler; actual commands can be loaded into client.commands
-client.once('ready', () => {
+client.once('ready', async () => {
   console.log(`Logged in as ${client.user.tag}`);
+
+  if (moderation) {
+    const bans = await db.Ban.find({ expiresAt: { $gt: new Date() } });
+    for (const ban of bans) {
+      try {
+        const guild = await client.guilds.fetch(ban.guildId);
+        await guild.members.ban(ban.userId, { reason: ban.reason });
+      } catch (err) {
+        console.error(`Failed to enforce ban for ${ban.userId}`, err);
+      }
+    }
+  }
 });
 
-client.on('messageCreate', (message) => {
+client.on('messageCreate', async (message) => {
   if (message.author.bot) return;
-  if (message.content === '!ping') {
-    message.reply('Pong!');
+  if (!message.content.startsWith('!')) return;
+
+  const args = message.content.trim().split(/\s+/);
+  const command = args.shift().toLowerCase();
+
+  if (command === '!ping') {
+    return message.reply('Pong!');
+  }
+
+  if (command === '!ban' && moderation) {
+    const user = message.mentions.users.first();
+    if (!user) return message.reply('Please mention a user to ban.');
+    const reason = args.slice(1).join(' ') || 'No reason provided';
+    try {
+      await moderation.banUser(client, message.guild.id, user.id, reason);
+      return message.reply(`Banned ${user.tag}`);
+    } catch (err) {
+      console.error('Ban failed:', err);
+      return message.reply('Failed to ban user.');
+    }
+  }
+
+  if (command === '!unban' && moderation) {
+    const userId = args[0];
+    if (!userId) return message.reply('Please provide a user ID to unban.');
+    try {
+      await moderation.unbanUser(client, message.guild.id, userId);
+      return message.reply(`Unbanned <@${userId}>`);
+    } catch (err) {
+      console.error('Unban failed:', err);
+      return message.reply('Failed to unban user.');
+    }
   }
 });
 
@@ -32,15 +89,7 @@ async function start() {
     throw new Error('DISCORD_BOT_TOKEN is not defined in environment variables.');
   }
 
-  const mongoUri = process.env.MONGODB_URI;
-  if (mongoUri) {
-    try {
-      await mongoose.connect(mongoUri);
-      console.log('Connected to MongoDB');
-    } catch (err) {
-      console.error('MongoDB connection error:', err);
-    }
-  }
+  await db.init();
 
   try {
     await client.login(token);

--- a/database/banModel.js
+++ b/database/banModel.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const banSchema = new mongoose.Schema({
+  userId: { type: String, required: true },
+  guildId: { type: String, required: true },
+  reason: { type: String },
+  expiresAt: { type: Date }
+});
+
+module.exports = mongoose.model('Ban', banSchema);

--- a/database/index.js
+++ b/database/index.js
@@ -1,0 +1,31 @@
+const mongoose = require('mongoose');
+const Ban = require('./banModel');
+
+async function init() {
+  const mongoUri = process.env.MONGODB_URI;
+  if (!mongoUri) {
+    console.warn('MONGODB_URI is not defined.');
+    return;
+  }
+  try {
+    await mongoose.connect(mongoUri);
+    console.log('Connected to MongoDB');
+  } catch (err) {
+    console.error('MongoDB connection error:', err);
+  }
+}
+
+function addBan(data) {
+  const ban = new Ban(data);
+  return ban.save();
+}
+
+function removeBan(guildId, userId) {
+  return Ban.deleteOne({ guildId, userId });
+}
+
+function getBan(guildId, userId) {
+  return Ban.findOne({ guildId, userId });
+}
+
+module.exports = { init, addBan, removeBan, getBan, Ban };

--- a/features/moderation.js
+++ b/features/moderation.js
@@ -1,0 +1,30 @@
+const { addBan, removeBan } = require('../database');
+
+/**
+ * Ban a user from a guild and record it in the database.
+ * @param {Client} client Discord.js client
+ * @param {string} guildId ID of the guild
+ * @param {string} userId ID of the user to ban
+ * @param {string} reason Reason for ban
+ * @param {object} [options] Additional options such as duration in ms
+ */
+async function banUser(client, guildId, userId, reason, options = {}) {
+  const guild = await client.guilds.fetch(guildId);
+  await guild.members.ban(userId, { reason, ...options });
+  const expiresAt = options.duration ? new Date(Date.now() + options.duration) : null;
+  await addBan({ userId, guildId, reason, expiresAt });
+}
+
+/**
+ * Remove a ban from a user and database.
+ * @param {Client} client Discord.js client
+ * @param {string} guildId ID of the guild
+ * @param {string} userId ID of the user to unban
+ */
+async function unbanUser(client, guildId, userId) {
+  const guild = await client.guilds.fetch(guildId);
+  await guild.members.unban(userId);
+  await removeBan(guildId, userId);
+}
+
+module.exports = { banUser, unbanUser };


### PR DESCRIPTION
## Summary
- add moderation feature and MongoDB-backed ban storage
- load features dynamically and enforce stored bans on startup
- document configuring MongoDB and using ban commands

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d26af520832e8bb2b2667f051768