### PR TITLE
Add global error handlers and improve moderation robustness

### DIFF
--- a/features/moderation.js
+++ b/features/moderation.js
@@ -9,10 +9,15 @@ const { addBan, removeBan } = require('../database');
  * @param {object} [options] Additional options such as duration in ms
  */
 async function banUser(client, guildId, userId, reason, options = {}) {
-  const guild = await client.guilds.fetch(guildId);
-  await guild.members.ban(userId, { reason, ...options });
-  const expiresAt = options.duration ? new Date(Date.now() + options.duration) : null;
-  await addBan({ userId, guildId, reason, expiresAt });
+  try {
+    const guild = await client.guilds.fetch(guildId);
+    await guild.members.ban(userId, { reason, ...options });
+    const expiresAt = options.duration ? new Date(Date.now() + options.duration) : null;
+    await addBan({ userId, guildId, reason, expiresAt });
+  } catch (err) {
+    console.error(`Error banning user ${userId} in guild ${guildId}:`, err);
+    throw err;
+  }
 }
 
 /**
@@ -22,9 +27,14 @@ async function banUser(client, guildId, userId, reason, options = {}) {
  * @param {string} userId ID of the user to unban
  */
 async function unbanUser(client, guildId, userId) {
-  const guild = await client.guilds.fetch(guildId);
-  await guild.members.unban(userId);
-  await removeBan(guildId, userId);
+  try {
+    const guild = await client.guilds.fetch(guildId);
+    await guild.members.unban(userId);
+    await removeBan(guildId, userId);
+  } catch (err) {
+    console.error(`Error unbanning user ${userId} in guild ${guildId}:`, err);
+    throw err;
+  }
 }
 
 module.exports = { banUser, unbanUser };


### PR DESCRIPTION
## Summary
- log unhandled promise rejections and uncaught exceptions globally
- guard `messageCreate` commands with top-level try/catch and user-facing error replies
- wrap moderation utilities in try/catch blocks with error logging

## Testing
- `npm test`
- `node --check features/moderation.js`


------
https://chatgpt.com/codex/tasks/task_e_6893d5f16bd8832e8a2e282350a8b936