### PR TITLE
Allow banning by ID or mention

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -64,11 +64,12 @@ client.on('messageCreate', async (message) => {
 
     if (command === '!ban' && moderation) {
       const user = message.mentions.users.first();
-      if (!user) return message.reply('Please mention a user to ban.');
+      const userId = user ? user.id : args[0];
+      if (!userId) return message.reply('Provide a user mention or ID to ban.');
       const reason = args.slice(1).join(' ') || 'No reason provided';
       try {
-        await moderation.banUser(client, message.guild.id, user.id, reason);
-        return message.reply(`Banned ${user.tag}`);
+        await moderation.banUser(client, message.guild.id, userId, reason);
+        return message.reply(`Banned ${user ? user.tag : userId}`);
       } catch (err) {
         console.error('Ban failed:', err);
         return message.reply('Failed to ban user.');


### PR DESCRIPTION
## Summary
- allow `!ban` to accept either a user mention or raw ID and show tag when available
- handle banning by ID in moderation logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d6ec1b6c832e93bdb3abe814e8e4