### PR TITLE
Add MongoDB native client and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,17 @@ Create a `.env` file with the following values:
 ```
 DISCORD_BOT_TOKEN=your_bot_token
 MONGODB_URI=your_mongodb_connection_string
+DB_PASSWORD=your_mongodb_user_password
 ```
 
 The bot connects to MongoDB to store active bans.
+
+### MongoDB Connections
+
+Mongoose is used for all schema-based operations, such as storing bans. If you need
+to interact with MongoDB using the native driver—for example, to test a raw
+connection—use `database/mongoClient.js`. This helper requires `DB_PASSWORD` to
+be set and exposes a `testMongoConnection()` function that pings the database.
 
 ## Commands
 

--- a/database/index.js
+++ b/database/index.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const Ban = require('./banModel');
+const { run: testMongoConnection } = require('./mongoClient');
 
 async function init() {
   const mongoUri = process.env.MONGODB_URI;
@@ -28,4 +29,4 @@ function getBan(guildId, userId) {
   return Ban.findOne({ guildId, userId });
 }
 
-module.exports = { init, addBan, removeBan, getBan, Ban };
+module.exports = { init, addBan, removeBan, getBan, Ban, testMongoConnection };

--- a/database/mongoClient.js
+++ b/database/mongoClient.js
@@ -1,0 +1,22 @@
+const { MongoClient, ServerApiVersion } = require('mongodb');
+const uri = `mongodb+srv://ZeroTwo:${process.env.DB_PASSWORD}@cluster0.47tj0.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0`;
+
+const client = new MongoClient(uri, {
+  serverApi: {
+    version: ServerApiVersion.v1,
+    strict: true,
+    deprecationErrors: true,
+  }
+});
+
+async function run() {
+  try {
+    await client.connect();
+    await client.db('admin').command({ ping: 1 });
+    console.log('Pinged your deployment. You successfully connected to MongoDB!');
+  } finally {
+    await client.close();
+  }
+}
+
+module.exports = { client, run };


### PR DESCRIPTION
## Summary
- add `database/mongoClient.js` using native driver with `DB_PASSWORD`
- expose `testMongoConnection` from `database/index.js`
- document `DB_PASSWORD` and native driver usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893da40f294832e80953756dcced4ba