### PR TITLE
Force MongoDB db name and document URI format

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ Create a `.env` file with the following values:
 
 ```
 DISCORD_BOT_TOKEN=your_bot_token
-MONGODB_URI=your_mongodb_connection_string
+MONGODB_URI=your_mongodb_connection_string_including_db_name
 DB_PASSWORD=your_mongodb_user_password
 ```
 
 The bot connects to MongoDB to store active bans.
+
+The `MONGODB_URI` must include the database name. For example:
+
+```
+MONGODB_URI=mongodb+srv://ZeroTwo:<password>@cluster0.47tj0.mongodb.net/Discord_Bot?retryWrites=true&w=majority&appName=Cluster0
+```
 
 ### MongoDB Connections
 

--- a/database/index.js
+++ b/database/index.js
@@ -9,7 +9,7 @@ async function init() {
     return;
   }
   try {
-    await mongoose.connect(mongoUri);
+    await mongoose.connect(mongoUri, { dbName: 'Discord_Bot' });
     console.log('Connected to MongoDB');
   } catch (err) {
     console.error('MongoDB connection error:', err);


### PR DESCRIPTION
## Summary
- Ensure Mongoose connects using the `Discord_Bot` database name.
- Document required `MONGODB_URI` format with example in README.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893deb2a6a0832ea4554fa9ab7b6c1f