### PR TITLE
Add MongoDB explain for ban queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ be set and exposes a `testMongoConnection()` function that pings the database.
 - `!ping` – basic ping.
 - `!ban @user [reason]` – bans the mentioned user and records the ban in the database.
 - `!unban <userId>` – removes a ban and unbans the user by ID.
+- `!banExplain` – displays MongoDB execution stats for the ban collection. Restricted to administrators and useful for diagnosing indexing issues.
 
 The bot re-applies active bans from the database on startup.
 

--- a/bot.js
+++ b/bot.js
@@ -1,5 +1,5 @@
 require('dotenv').config();
-const { Client, GatewayIntentBits, Collection, Partials } = require('discord.js');
+const { Client, GatewayIntentBits, Collection, Partials, PermissionsBitField } = require('discord.js');
 const fs = require('fs');
 const path = require('path');
 const db = require('./database');
@@ -85,6 +85,18 @@ client.on('messageCreate', async (message) => {
       } catch (err) {
         console.error('Unban failed:', err);
         return message.reply('Failed to unban user.');
+      }
+    }
+
+    if (command === '!banexplain' && moderation) {
+      if (!message.member?.permissions.has(PermissionsBitField.Flags.Administrator)) {
+        return message.reply('This command is restricted to administrators.');
+      }
+      try {
+        await moderation.explainBanQuery(client, message);
+      } catch (err) {
+        console.error('Explain failed:', err);
+        return message.reply('Failed to retrieve query stats.');
       }
     }
   } catch (err) {

--- a/features/moderation.js
+++ b/features/moderation.js
@@ -1,4 +1,4 @@
-const { addBan, removeBan } = require('../database');
+const { addBan, removeBan, Ban } = require('../database');
 
 /**
  * Ban a user from a guild and record it in the database.
@@ -37,4 +37,29 @@ async function unbanUser(client, guildId, userId) {
   }
 }
 
-module.exports = { banUser, unbanUser };
+/**
+ * Explain query execution for the Ban collection.
+ * Useful for diagnosing MongoDB indexing issues.
+ * @param {Client} client Discord.js client (unused but kept for parity)
+ * @param {Message} message Discord.js message to respond to
+ */
+async function explainBanQuery(client, message) {
+  try {
+    const stats = await Ban.collection.find().explain('executionStats');
+    const json = JSON.stringify(stats, null, 2);
+    if (message && message.channel) {
+      // Discord has a 2000 character limit per message
+      const output = json.length > 1900 ? json.slice(0, 1900) + '\n... (truncated)' : json;
+      await message.channel.send(`\`\`\`json\n${output}\n\`\`\``);
+    } else {
+      console.log(json);
+    }
+  } catch (err) {
+    console.error('Failed to explain Ban query:', err);
+    if (message && message.channel) {
+      await message.channel.send('Failed to retrieve query stats.');
+    }
+  }
+}
+
+module.exports = { banUser, unbanUser, explainBanQuery };


### PR DESCRIPTION
## Summary
- add `explainBanQuery` helper to log MongoDB execution stats for bans
- register `!banExplain` command restricted to admins
- document usage for diagnosing indexing issues

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e100eaac832e8e42ef94ee2c22a7