### PR TITLE
Add helper for active bans and use in ready event

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -38,7 +38,7 @@ client.once('ready', async () => {
   console.log(`Logged in as ${client.user.tag}`);
 
   if (moderation) {
-    const bans = await db.Ban.find({ expiresAt: { $gt: new Date() } });
+    const bans = await db.getActiveBans();
     for (const ban of bans) {
       try {
         const guild = await client.guilds.fetch(ban.guildId);

--- a/database/index.js
+++ b/database/index.js
@@ -33,8 +33,12 @@ function getBan(guildId, userId) {
   return bans.findOne({ userId, guildId });
 }
 
+async function getActiveBans() {
+  return await bans.find({ expiresAt: { $gt: new Date() } }).toArray();
+}
+
 async function close() {
   await client.close();
 }
 
-module.exports = { init, addBan, removeBan, getBan, close };
+module.exports = { init, addBan, removeBan, getBan, getActiveBans, close };


### PR DESCRIPTION
## Summary
- add `getActiveBans` helper in database layer
- update bot to call `db.getActiveBans()` instead of `db.Ban`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e6104394832ea8f35f96ed3c8e9a