### PR TITLE
Use collection accessor for ban queries

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -37,8 +37,12 @@ async function getActiveBans() {
   return await bans.find({ expiresAt: { $gt: new Date() } }).toArray();
 }
 
+function getBanCollection() {
+  return bans;
+}
+
 async function close() {
   await client.close();
 }
 
-module.exports = { init, addBan, removeBan, getBan, getActiveBans, close };
+module.exports = { init, addBan, removeBan, getBan, getActiveBans, getBanCollection, close };

--- a/features/moderation.js
+++ b/features/moderation.js
@@ -1,4 +1,4 @@
-const { addBan, removeBan, Ban } = require('../database');
+const { addBan, removeBan, getBanCollection } = require('../database');
 
 /**
  * Ban a user from a guild and record it in the database.
@@ -45,7 +45,8 @@ async function unbanUser(client, guildId, userId) {
  */
 async function explainBanQuery(client, message) {
   try {
-    const stats = await Ban.collection.find().explain('executionStats');
+    const banCollection = getBanCollection();
+    const stats = await banCollection.find().explain('executionStats');
     const json = JSON.stringify(stats, null, 2);
     if (message && message.channel) {
       // Discord has a 2000 character limit per message


### PR DESCRIPTION
## Summary
- expose `getBanCollection` from database helper
- update moderation feature to use collection accessor instead of model import

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e6c79f04832eabbe4e0237dd1095