### PR TITLE
Add initialization guard for database operations

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -3,6 +3,13 @@ const { MongoClient } = require('mongodb');
 let client;
 let bans;
 
+function ensureBans() {
+  if (!bans) {
+    console.warn('Bans collection is not initialized. Call init() first.');
+    throw new Error('Database not initialized');
+  }
+}
+
 async function init() {
   const mongoUri = process.env.MONGODB_URI;
   if (!mongoUri) {
@@ -21,23 +28,28 @@ async function init() {
 }
 
 async function addBan(data) {
+  ensureBans();
   const { userId, guildId } = data;
   await bans.updateOne({ userId, guildId }, { $set: data }, { upsert: true });
 }
 
 function removeBan(guildId, userId) {
+  ensureBans();
   return bans.deleteOne({ userId, guildId });
 }
 
 function getBan(guildId, userId) {
+  ensureBans();
   return bans.findOne({ userId, guildId });
 }
 
 async function getActiveBans() {
+  ensureBans();
   return await bans.find({ expiresAt: { $gt: new Date() } }).toArray();
 }
 
 function getBanCollection() {
+  ensureBans();
   return bans;
 }
 


### PR DESCRIPTION
## Summary
- prevent database operations before the MongoDB connection initializes
- log a warning when the bans collection is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893e7967220832e97fdd45caf0bce0b