### PR TITLE
Handle MongoDB initialization failures

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -115,7 +115,12 @@ async function start() {
     throw new Error('DISCORD_BOT_TOKEN is not defined in environment variables.');
   }
 
-  await db.init();
+  try {
+    await db.init();
+  } catch (err) {
+    console.error('Failed to initialize database:', err);
+    throw err;
+  }
 
   try {
     await client.login(token);

--- a/database/index.js
+++ b/database/index.js
@@ -14,7 +14,7 @@ async function init() {
   const mongoUri = process.env.MONGODB_URI;
   if (!mongoUri) {
     console.warn('MONGODB_URI is not defined.');
-    return;
+    throw new Error('MONGODB_URI is not defined');
   }
   client = new MongoClient(mongoUri);
   try {
@@ -24,6 +24,7 @@ async function init() {
     console.log('Connected to MongoDB');
   } catch (err) {
     console.error('MongoDB connection error:', err);
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary
- throw explicit error when MONGODB_URI is missing
- rethrow MongoDB connection errors
- abort bot startup when database init fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e94a5c90832e9d4c1b8cf589fc67