### PR TITLE
feat: allow configurable MongoDB database

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ Create a `.env` file with the following values:
 ```
 DISCORD_BOT_TOKEN=your_bot_token
 MONGODB_URI=your_mongodb_connection_string
+MONGODB_DB=your_application_database_name
 DB_PASSWORD=your_mongodb_user_password
 ```
 
-The bot connects to MongoDB to store active bans.
+The URI should include any authentication options, such as `authSource=admin`,
+which specifies where credentials are verified. `MONGODB_DB` (or the database
+named in the URI path) selects the database the bot uses to store its data. The
+bot connects to MongoDB to store active bans.
 
 ### MongoDB Connections
 

--- a/database/index.js
+++ b/database/index.js
@@ -1,5 +1,9 @@
 const { MongoClient } = require('mongodb');
 
+const url = new URL(process.env.MONGODB_URI);
+const dbName =
+  process.env.MONGODB_DB || url.pathname.replace(/^\//, '') || 'Discord_Bot';
+
 let client;
 let bans;
 
@@ -19,7 +23,7 @@ async function init() {
   client = new MongoClient(mongoUri);
   try {
     await client.connect();
-    const db = client.db('Discord_Bot');
+    const db = client.db(dbName);
     bans = db.collection('ban');
     console.log('Connected to MongoDB');
   } catch (err) {


### PR DESCRIPTION
## Summary
- compute MongoDB database name from `MONGODB_URI` and optional `MONGODB_DB`
- use computed `dbName` when creating the database connection
- document `MONGODB_DB` and clarify `authSource` vs application database

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893f45b55c4832e9a6caf63bda75bbb