### PR TITLE
feat: add help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ be set and exposes a `testMongoConnection()` function that pings the database.
 ## Commands
 
 - `!ping` – basic ping.
-- `!ban @user [reason]` – bans the mentioned user and records the ban in the database.
-- `!unban <userId>` – removes a ban and unbans the user by ID.
+- `!help` – list available commands.
+- `!ban @user [reason]` – bans the mentioned user and records the ban in the database. Requires the moderation feature and appropriate permissions.
+- `!unban <userId>` – removes a ban and unbans the user by ID. Requires the moderation feature and appropriate permissions.
 - `!banExplain` – displays MongoDB execution stats for the ban collection. Restricted to administrators and useful for diagnosing indexing issues.
 
 The bot re-applies active bans from the database on startup.

--- a/bot.js
+++ b/bot.js
@@ -21,6 +21,14 @@ if (fs.existsSync(featuresPath)) {
 }
 const moderation = features.moderation;
 
+// Command descriptions used for help text
+const commandDescriptions = {
+  '!ping': '`!ping` - Check bot responsiveness.',
+  '!ban': '`!ban <@user|userId> [reason]` - Ban a user and record the reason.',
+  '!unban': '`!unban <userId>` - Remove a ban and unban the user.',
+  '!banexplain': '`!banexplain` - *Admin only.* Show MongoDB query stats for the ban collection.'
+};
+
 // Create Discord client with desired intents
 const client = new Client({
   intents: [
@@ -69,6 +77,15 @@ client.on('messageCreate', async (message) => {
 
     if (command === '!ping') {
       return message.reply('Pong!');
+    }
+
+    if (command === '!help') {
+      const lines = ['**Available Commands**'];
+      for (const [cmd, desc] of Object.entries(commandDescriptions)) {
+        if (!moderation && ['!ban', '!unban', '!banexplain'].includes(cmd)) continue;
+        lines.push(desc);
+      }
+      return message.channel.send(lines.join('\n'));
     }
 
     if (command === '!ban' && moderation) {


### PR DESCRIPTION
## Summary
- add `!help` command to list available commands and auto-hide moderation features when disabled
- document `!help` and moderation requirements for `!ban`/`!unban`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893f75080cc832e9f212f2d7c865c5e