### PR TITLE
feat: centralize ban enforcement in moderation feature

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -19,8 +19,6 @@ if (fs.existsSync(featuresPath)) {
     }
   }
 }
-const moderation = features.moderation;
-
 // Shared command map for help text
 const commands = new Map();
 
@@ -45,27 +43,6 @@ for (const feature of Object.values(features)) {
 
 client.once('ready', async () => {
   console.log(`Logged in as ${client.user.tag}`);
-
-  if (moderation) {
-    // Ensure the database is available before trying to enforce bans
-    if (typeof db.isInitialized === 'function' && !db.isInitialized()) {
-      console.warn('Database not initialized; skipping ban enforcement.');
-    } else {
-      try {
-        const bans = await db.getActiveBans();
-        for (const ban of bans) {
-          try {
-            const guild = await client.guilds.fetch(ban.guildId);
-            await guild.members.ban(ban.userId, { reason: ban.reason });
-          } catch (err) {
-            console.error(`Failed to enforce ban for ${ban.userId}`, err);
-          }
-        }
-      } catch (err) {
-        console.warn('Database unavailable; skipping ban enforcement.', err);
-      }
-    }
-  }
 });
 
 async function start() {


### PR DESCRIPTION
## Summary
- streamline moderation feature to expose only `register`
- add moderation `ready` handler to enforce stored bans
- simplify bot ready event to logging only

## Testing
- `node --check features/moderation.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893face3898832eadd66ffb5099a355