### PR TITLE
Add warning system with auto escalation

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -6,10 +6,18 @@ const dbName =
 
 let client;
 let bans;
+let warnings;
 
 function ensureBans() {
   if (!bans) {
     console.warn('Bans collection is not initialized. Call init() first.');
+    throw new Error('Database not initialized');
+  }
+}
+
+function ensureWarnings() {
+  if (!warnings) {
+    console.warn('Warnings collection is not initialized. Call init() first.');
     throw new Error('Database not initialized');
   }
 }
@@ -25,6 +33,7 @@ async function init() {
     await client.connect();
     const db = client.db(dbName);
     bans = db.collection('ban');
+    warnings = db.collection('warnings');
     console.log('Connected to MongoDB');
   } catch (err) {
     console.error('MongoDB connection error:', err);
@@ -58,8 +67,36 @@ function getBanCollection() {
   return bans;
 }
 
+async function addWarning(data) {
+  ensureWarnings();
+  const doc = { ...data, createdAt: new Date() };
+  await warnings.insertOne(doc);
+  return doc;
+}
+
+function listWarnings(guildId, userId) {
+  ensureWarnings();
+  return warnings.find({ guildId, userId }).sort({ createdAt: 1 }).toArray();
+}
+
+function clearWarnings(guildId, userId) {
+  ensureWarnings();
+  return warnings.deleteMany({ guildId, userId });
+}
+
 async function close() {
   await client.close();
 }
 
-module.exports = { init, addBan, removeBan, getBan, getActiveBans, getBanCollection, close };
+module.exports = {
+  init,
+  addBan,
+  removeBan,
+  getBan,
+  getActiveBans,
+  getBanCollection,
+  addWarning,
+  listWarnings,
+  clearWarnings,
+  close
+};

--- a/features/warn.js
+++ b/features/warn.js
@@ -1,0 +1,51 @@
+const { addWarning, listWarnings } = require('../database');
+
+function register(client, commands) {
+  commands.set('!warn', '`!warn <@user|userId> [reason]` - Log a warning for a user.');
+  commands.set('!warnings', '`!warnings <userId>` - List warnings for a user.');
+
+  client.on('messageCreate', async (message) => {
+    try {
+      if (message.author.bot) return;
+      if (!message.content.startsWith('!')) return;
+      if (!message.guild) return;
+
+      const args = message.content.trim().split(/\s+/);
+      const command = args.shift().toLowerCase();
+
+      if (command === '!warn') {
+        const user = message.mentions.users.first();
+        const userId = user ? user.id : args.shift();
+        if (!userId) return message.reply('Provide a user mention or ID to warn.');
+        const reason = args.join(' ') || 'No reason provided';
+        await addWarning({ guildId: message.guild.id, userId, reason });
+        await message.reply(`Warning recorded for <@${userId}>: ${reason}`);
+        try {
+          const warnings = await listWarnings(message.guild.id, userId);
+          if (warnings.length >= 3) {
+            const member = await message.guild.members.fetch(userId);
+            await member.timeout(10 * 60 * 1000, 'Auto-mute after 3 warnings');
+            await message.channel.send(`Auto-muted <@${userId}> for repeated warnings.`);
+          }
+        } catch (err) {
+          console.error('Failed to check warnings:', err);
+        }
+      }
+
+      if (command === '!warnings') {
+        const userId = args[0];
+        if (!userId) return message.reply('Provide a user ID to view warnings.');
+        const warnings = await listWarnings(message.guild.id, userId);
+        if (!warnings.length) {
+          return message.reply('No warnings found for that user.');
+        }
+        const lines = warnings.map((w, i) => `${i + 1}. ${w.reason} - ${w.createdAt.toISOString()}`);
+        return message.channel.send(`Warnings for <@${userId}>:\n${lines.join('\n')}`);
+      }
+    } catch (err) {
+      console.error('Error handling warning command:', err);
+    }
+  });
+}
+
+module.exports = { register };


### PR DESCRIPTION
## Summary
- add `!warn` and `!warnings` commands to log and list user infractions
- support automatic muting after three warnings
- introduce MongoDB `warnings` collection and helpers

## Testing
- `npm test`
- `node --check features/warn.js`
- `node --check database/index.js`


------
https://chatgpt.com/codex/tasks/task_e_6893feb35350832eb214ac8d6eb00189