### PR TITLE
feat: add per-guild mod-log configuration

### DIFF
--- a/features/modlog.js
+++ b/features/modlog.js
@@ -1,49 +1,89 @@
-const { EmbedBuilder } = require('discord.js');
+const { EmbedBuilder, PermissionsBitField } = require('discord.js');
+const { setModLogChannel, getModLogChannel } = require('../database');
 
 function register(client, commands) {
-  const channelId = process.env.MODLOG_CHANNEL_ID;
-  if (!channelId) {
-    console.warn('MODLOG_CHANNEL_ID is not set; moderation logging disabled.');
-    return;
-  }
+  commands.set(
+    '!setmodlog',
+    '`!setmodlog <#channel>` - Set the channel where moderation actions are logged.'
+  );
 
-  let modChannel = null;
+  const modLogChannels = new Map();
 
   client.once('ready', async () => {
     try {
-      modChannel = await client.channels.fetch(channelId);
+      for (const guild of client.guilds.cache.values()) {
+        const channelId = await getModLogChannel(guild.id);
+        if (channelId) {
+          modLogChannels.set(guild.id, channelId);
+        }
+      }
     } catch (err) {
-      console.warn('Failed to fetch mod-log channel:', err);
+      console.warn('Failed to load mod-log channels:', err);
     }
   });
 
-  async function sendLog(action, data = {}) {
-    if (!modChannel) {
-      console.warn('Mod-log channel not available; skipping log.');
-      return;
-    }
+  client.on('messageCreate', async (message) => {
     try {
+      if (message.author.bot) return;
+      if (!message.guild) return;
+      if (!message.content.startsWith('!')) return;
+
+      const args = message.content.trim().split(/\s+/);
+      const command = args.shift().toLowerCase();
+
+      if (command === '!setmodlog') {
+        if (!message.member?.permissions.has(PermissionsBitField.Flags.ManageGuild)) {
+          return message.reply('You do not have permission to use this command.');
+        }
+        const channel = message.mentions.channels.first();
+        if (!channel) {
+          return message.reply('Please mention a channel to set as the mod-log.');
+        }
+        try {
+          await setModLogChannel(message.guild.id, channel.id);
+          modLogChannels.set(message.guild.id, channel.id);
+          return message.reply(`Mod-log channel set to ${channel}.`);
+        } catch (err) {
+          console.error('Failed to set mod-log channel:', err);
+          return message.reply('Failed to set mod-log channel.');
+        }
+      }
+    } catch (err) {
+      console.error('Error handling modlog command:', err);
+    }
+  });
+
+  async function sendLog(guildId, action, data = {}) {
+    const channelId = modLogChannels.get(guildId);
+    if (!channelId) return;
+
+    try {
+      const channel = await client.channels.fetch(channelId);
       const embed = new EmbedBuilder()
         .setTitle(action)
         .setColor(0xff0000)
         .setTimestamp();
 
-      if (data.userId) embed.addFields({ name: 'User', value: `<@${data.userId}>`, inline: true });
-      if (data.moderatorId) embed.addFields({ name: 'Moderator', value: `<@${data.moderatorId}>`, inline: true });
-      if (data.duration) embed.addFields({ name: 'Duration', value: String(data.duration), inline: true });
+      if (data.userId)
+        embed.addFields({ name: 'User', value: `<@${data.userId}>`, inline: true });
+      if (data.moderatorId)
+        embed.addFields({ name: 'Moderator', value: `<@${data.moderatorId}>`, inline: true });
+      if (data.duration)
+        embed.addFields({ name: 'Duration', value: String(data.duration), inline: true });
       if (data.reason) embed.addFields({ name: 'Reason', value: data.reason });
 
-      await modChannel.send({ embeds: [embed] });
+      await channel.send({ embeds: [embed] });
     } catch (err) {
       console.error(`Failed to send ${action} log:`, err);
     }
   }
 
-  client.on('ban', (data) => sendLog('Ban', data));
-  client.on('unban', (data) => sendLog('Unban', data));
-  client.on('kick', (data) => sendLog('Kick', data));
-  client.on('mute', (data) => sendLog('Mute', data));
-  client.on('warn', (data) => sendLog('Warn', data));
+  client.on('ban', (data) => sendLog(data.guildId, 'Ban', data));
+  client.on('unban', (data) => sendLog(data.guildId, 'Unban', data));
+  client.on('kick', (data) => sendLog(data.guildId, 'Kick', data));
+  client.on('mute', (data) => sendLog(data.guildId, 'Mute', data));
+  client.on('warn', (data) => sendLog(data.guildId, 'Warn', data));
 }
 
 module.exports = { register };
+


### PR DESCRIPTION
## Summary
- add guildSettings collection with helpers to store mod-log channel per guild
- allow setting and using per-guild mod-log channels via `!setmodlog`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894027ec688832ea11b7fc29cca3725