### PR TITLE
feat: add modmail system

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -27,9 +27,11 @@ const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildMessages,
-    GatewayIntentBits.MessageContent
+    GatewayIntentBits.MessageContent,
+    GatewayIntentBits.DirectMessages,
+    GatewayIntentBits.DirectMessageReactions
   ],
-  partials: [Partials.Channel]
+  partials: [Partials.Channel, Partials.Message, Partials.Reaction]
 });
 
 client.features = features;

--- a/features/modlog.js
+++ b/features/modlog.js
@@ -83,6 +83,9 @@ function register(client, commands) {
   client.on('kick', (data) => sendLog(data.guildId, 'Kick', data));
   client.on('mute', (data) => sendLog(data.guildId, 'Mute', data));
   client.on('warn', (data) => sendLog(data.guildId, 'Warn', data));
+  client.on('modmail', (data) =>
+    sendLog(data.guildId, `Modmail ${data.action}`, data)
+  );
 }
 
 module.exports = { register };

--- a/features/modmail.js
+++ b/features/modmail.js
@@ -1,0 +1,73 @@
+const { EmbedBuilder, PermissionsBitField, PermissionFlagsBits, ChannelType } = require('discord.js');
+
+const MAIN_GUILD_ID = '1165456303209054208';
+
+function register(client, commands) {
+  client.on('messageCreate', async (message) => {
+    try {
+      if (message.author.bot) return;
+      if (message.guild) return;
+
+      const promptEmbed = new EmbedBuilder()
+        .setTitle('Open a Modmail Ticket?')
+        .setDescription('React with ✅ to confirm or 🚫 to cancel.');
+
+      const prompt = await message.channel.send({ embeds: [promptEmbed] });
+      await prompt.react('✅');
+      await prompt.react('🚫');
+
+      const filter = (reaction, user) =>
+        user.id === message.author.id && ['✅', '🚫'].includes(reaction.emoji.name);
+      const collected = await prompt.awaitReactions({ filter, max: 1, time: 60000 });
+      const reaction = collected.first();
+
+      if (!reaction || reaction.emoji.name === '🚫') {
+        const cancelEmbed = new EmbedBuilder().setDescription('Modmail request cancelled.');
+        await message.channel.send({ embeds: [cancelEmbed] });
+        client.emit('modmail', {
+          guildId: MAIN_GUILD_ID,
+          userId: message.author.id,
+          action: 'Cancelled'
+        });
+        return;
+      }
+
+      const guild = await client.guilds.fetch(MAIN_GUILD_ID);
+      const staffRole = guild.roles.cache.find((r) =>
+        r.permissions.has(PermissionsBitField.Flags.ManageGuild)
+      );
+
+      const channel = await guild.channels.create({
+        name: `modmail-${message.author.id}`,
+        type: ChannelType.GuildText,
+        permissionOverwrites: [
+          { id: guild.roles.everyone.id, deny: [PermissionFlagsBits.ViewChannel] },
+          ...(staffRole
+            ? [{ id: staffRole.id, allow: [PermissionFlagsBits.ViewChannel] }]
+            : [])
+        ]
+      });
+
+      await channel.send(
+        `New modmail from <@${message.author.id}>:\n${message.content}`
+      );
+
+      const confirmEmbed = new EmbedBuilder().setDescription(
+        'Your ticket has been opened. Staff will reply soon.'
+      );
+      await message.channel.send({ embeds: [confirmEmbed] });
+
+      client.emit('modmail', {
+        guildId: MAIN_GUILD_ID,
+        userId: message.author.id,
+        action: 'Opened',
+        channelId: channel.id
+      });
+    } catch (err) {
+      console.error('Error handling modmail:', err);
+    }
+  });
+}
+
+module.exports = { register };
+


### PR DESCRIPTION
## Summary
- handle direct messages by enabling DM intents and partials
- add modmail ticket workflow for user DMs
- log modmail open/cancel events to mod log channel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894056f0c2c832ea3bfb3b3cbe94b37