### PR TITLE
feat: add modmail ticket assignment

### DIFF
--- a/features/modmail.js
+++ b/features/modmail.js
@@ -1,12 +1,40 @@
-const { EmbedBuilder, PermissionsBitField, PermissionFlagsBits, ChannelType } = require('discord.js');
+const {
+  EmbedBuilder,
+  PermissionsBitField,
+  PermissionFlagsBits,
+  ChannelType
+} = require('discord.js');
 
 const MAIN_GUILD_ID = '1165456303209054208';
 
+// Track active tickets keyed by user ID
+// { channelId, assignedAdminId }
+const activeTickets = new Map();
+
 function register(client, commands) {
+  // DM listener - open tickets and forward user messages
   client.on('messageCreate', async (message) => {
     try {
       if (message.author.bot) return;
       if (message.guild) return;
+
+      const ticket = activeTickets.get(message.author.id);
+      if (ticket) {
+        const channel = await client.channels
+          .fetch(ticket.channelId)
+          .catch(() => null);
+        if (channel) {
+          const embed = new EmbedBuilder()
+            .setAuthor({
+              name: message.author.tag,
+              iconURL: message.author.displayAvatarURL()
+            })
+            .setDescription(message.content)
+            .setTimestamp();
+          await channel.send({ embeds: [embed] });
+        }
+        return;
+      }
 
       const promptEmbed = new EmbedBuilder()
         .setTitle('Open a Modmail Ticket?')
@@ -49,14 +77,27 @@ function register(client, commands) {
         ]
       });
 
-      await channel.send(
-        `New modmail from <@${message.author.id}>:\n${message.content}`
-      );
+      const firstEmbed = new EmbedBuilder()
+        .setAuthor({
+          name: message.author.tag,
+          iconURL: message.author.displayAvatarURL()
+        })
+        .setDescription(message.content)
+        .setTimestamp();
+      await channel.send({
+        content: `New modmail from <@${message.author.id}>:`,
+        embeds: [firstEmbed]
+      });
 
       const confirmEmbed = new EmbedBuilder().setDescription(
         'Your ticket has been opened. Staff will reply soon.'
       );
       await message.author.send({ embeds: [confirmEmbed] });
+
+      activeTickets.set(message.author.id, {
+        channelId: channel.id,
+        assignedAdminId: null
+      });
 
       client.emit('modmail', {
         guildId: MAIN_GUILD_ID,
@@ -66,6 +107,62 @@ function register(client, commands) {
       });
     } catch (err) {
       console.error('Error handling modmail:', err);
+    }
+  });
+
+  // Guild listener - forward assigned admin messages and handle claiming
+  client.on('messageCreate', async (message) => {
+    try {
+      if (message.author.bot) return;
+      if (!message.guild) return;
+
+      let userId = null;
+      for (const [uid, ticket] of activeTickets.entries()) {
+        if (ticket.channelId === message.channel.id) {
+          userId = uid;
+          break;
+        }
+      }
+      if (!userId) return;
+
+      const ticket = activeTickets.get(userId);
+      const content = message.content.trim().toLowerCase();
+
+      if (content === '!claim') {
+        if (ticket.assignedAdminId && ticket.assignedAdminId !== message.author.id) {
+          await message.reply('Ticket already claimed.');
+        } else if (ticket.assignedAdminId === message.author.id) {
+          await message.reply('You have already claimed this ticket.');
+        } else {
+          ticket.assignedAdminId = message.author.id;
+          await message.reply(`Ticket claimed by <@${message.author.id}>.`);
+        }
+        return;
+      }
+
+      if (content === '!unclaim') {
+          if (ticket.assignedAdminId !== message.author.id) {
+            await message.reply('You are not the assigned admin.');
+          } else {
+            ticket.assignedAdminId = null;
+            await message.reply('Ticket unclaimed.');
+          }
+          return;
+      }
+
+      if (ticket.assignedAdminId === message.author.id) {
+        const user = await client.users.fetch(userId);
+        const embed = new EmbedBuilder()
+          .setAuthor({
+            name: message.author.tag,
+            iconURL: message.author.displayAvatarURL()
+          })
+          .setDescription(message.content)
+          .setTimestamp();
+        await user.send({ embeds: [embed] });
+      }
+    } catch (err) {
+      console.error('Error relaying modmail message:', err);
     }
   });
 }


### PR DESCRIPTION
## Summary
- track active modmail tickets and assigned admins
- forward user DMs and admin replies between DM and ticket channel
- add claim and unclaim commands for ticket channels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68941d29c034832e83a7091386122394