### PR TITLE
Allow customizable birthday formats

### DIFF
--- a/database/index.js
+++ b/database/index.js
@@ -11,6 +11,8 @@ let mutes;
 let guildSettings;
 let birthdays;
 
+const DEFAULT_BIRTHDAY_FORMAT = 'YYYY-MM-DD';
+
 function ensureBans() {
   if (!bans) {
     console.warn('Bans collection is not initialized. Call init() first.');
@@ -203,7 +205,7 @@ async function setBirthdayFormat(guildId, format) {
 async function getBirthdayFormat(guildId) {
   ensureGuildSettings();
   const doc = await guildSettings.findOne({ guildId });
-  return doc ? doc.birthdayFormat : null;
+  return doc && doc.birthdayFormat ? doc.birthdayFormat : DEFAULT_BIRTHDAY_FORMAT;
 }
 
 async function close() {


### PR DESCRIPTION
## Summary
- add default birthdayFormat field to guildSettings with helpers
- parse and display birthdays using a guild's configured format
- document supported formats in the help entry for birthday format command

## Testing
- `node --check features/birthdays.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689425925570832e962471d46bdab48b