### PR TITLE
feat: categorize commands for richer help

### DIFF
--- a/features/birthdays.js
+++ b/features/birthdays.js
@@ -79,24 +79,40 @@ function parseDate(dateStr, format) {
 }
 
 function register(client, commands) {
-  commands.set(
-    '!setbirthday',
-    '`!setbirthday <date>` - store your birthday using the server\'s format.'
-  );
-  commands.set('!clearbirthday', '`!clearbirthday` - remove your birthday.');
-  commands.set('!birthdays', '`!birthdays` - list upcoming birthdays.');
-  commands.set(
-    '!setbirthdaychannel',
-    '`!setbirthdaychannel <#channel>` - set channel for birthday messages (ManageGuild).'
-  );
-  commands.set(
-    '!setbirthdayrole',
-    '`!setbirthdayrole <@role>` - set role assigned on birthdays (ManageGuild).'
-  );
-  commands.set(
-    '!setbirthdayformat',
-    `!setbirthdayformat <format> - set birthday date format. Formats: ${DATE_FORMATS.join(', ')} (ManageGuild).`
-  );
+  commands.set('!setbirthday', {
+    description:
+      "`!setbirthday <date>` - store your birthday using the server's format.",
+    category: 'Birthdays',
+    adminOnly: false
+  });
+  commands.set('!clearbirthday', {
+    description: '`!clearbirthday` - remove your birthday.',
+    category: 'Birthdays',
+    adminOnly: false
+  });
+  commands.set('!birthdays', {
+    description: '`!birthdays` - list upcoming birthdays.',
+    category: 'Birthdays',
+    adminOnly: false
+  });
+  commands.set('!setbirthdaychannel', {
+    description:
+      '`!setbirthdaychannel <#channel>` - set channel for birthday messages (ManageGuild).',
+    category: 'Birthdays',
+    adminOnly: true
+  });
+  commands.set('!setbirthdayrole', {
+    description:
+      '`!setbirthdayrole <@role>` - set role assigned on birthdays (ManageGuild).',
+    category: 'Birthdays',
+    adminOnly: true
+  });
+  commands.set('!setbirthdayformat', {
+    description:
+      `!setbirthdayformat <format> - set birthday date format. Formats: ${DATE_FORMATS.join(', ')} (ManageGuild).`,
+    category: 'Birthdays',
+    adminOnly: true
+  });
 
   client.on('messageCreate', async (message) => {
     try {

--- a/features/help.js
+++ b/features/help.js
@@ -1,5 +1,11 @@
+const { EmbedBuilder } = require('discord.js');
+
 function register(client, commands) {
-  commands.set('!help', '`!help` - Show available commands.');
+  commands.set('!help', {
+    description: '`!help` - Show available commands.',
+    category: 'General',
+    adminOnly: false
+  });
 
   client.on('messageCreate', async (message) => {
     try {
@@ -10,11 +16,52 @@ function register(client, commands) {
       const command = args.shift().toLowerCase();
 
       if (command === '!help') {
-        const lines = ['**Available Commands**'];
-        for (const [, desc] of commands) {
-          lines.push(desc);
+        const categoryEmojis = {
+          General: '💬',
+          Birthdays: '🎂',
+          Modmail: '📬',
+          Moderation: '🛡️'
+        };
+
+        const userCategories = new Map();
+        const adminCategories = new Map();
+        for (const [, info] of commands) {
+          const target = info.adminOnly ? adminCategories : userCategories;
+          if (!target.has(info.category)) target.set(info.category, []);
+          target.get(info.category).push(info.description);
         }
-        return message.channel.send(lines.join('\n'));
+
+        const randomColor = () => Math.floor(Math.random() * 0xffffff);
+        const embeds = [];
+
+        if (userCategories.size) {
+          const embed = new EmbedBuilder()
+            .setTitle('Available Commands')
+            .setColor(randomColor());
+          for (const [cat, lines] of userCategories) {
+            const name = `${categoryEmojis[cat] ?? ''} ${cat}`.trim();
+            embed.addFields({ name, value: lines.join('\n') });
+          }
+          embeds.push(embed);
+        }
+
+        if (adminCategories.size) {
+          const embed = new EmbedBuilder()
+            .setTitle('ADMIN ONLY')
+            .setColor(randomColor());
+          for (const [cat, lines] of adminCategories) {
+            const name = `${categoryEmojis[cat] ?? ''} ${cat}`.trim();
+            embed.addFields({ name, value: lines.join('\n') });
+          }
+          embeds.push(embed);
+        }
+
+        try {
+          await message.author.send({ embeds });
+          await message.reply('📬 Check your DMs for the command list!');
+        } catch (err) {
+          await message.reply("❌ I couldn't send you the command list. Please enable DMs.");
+        }
       }
     } catch (err) {
       console.error('Error handling help command:', err);

--- a/features/moderation.js
+++ b/features/moderation.js
@@ -65,13 +65,27 @@ async function explainBanQuery(client, message) {
 }
 
 function register(client, commands) {
-  commands.set('!ban', '`!ban <@user|userId> [reason]` - Ban a user and record the reason.');
-  commands.set('!unban', '`!unban <userId>` - Remove a ban and unban the user.');
-  commands.set('!kick', '`!kick <@user|userId> [reason]` - Kick a user from the guild.');
-  commands.set(
-    '!banexplain',
-    '`!banexplain` - *Admin only.* Show MongoDB query stats for the ban collection.'
-  );
+  commands.set('!ban', {
+    description: '`!ban <@user|userId> [reason]` - Ban a user and record the reason.',
+    category: 'Moderation',
+    adminOnly: true
+  });
+  commands.set('!unban', {
+    description: '`!unban <userId>` - Remove a ban and unban the user.',
+    category: 'Moderation',
+    adminOnly: true
+  });
+  commands.set('!kick', {
+    description: '`!kick <@user|userId> [reason]` - Kick a user from the guild.',
+    category: 'Moderation',
+    adminOnly: true
+  });
+  commands.set('!banexplain', {
+    description:
+      '`!banexplain` - *Admin only.* Show MongoDB query stats for the ban collection.',
+    category: 'Moderation',
+    adminOnly: true
+  });
 
   client.on('messageCreate', async (message) => {
     try {

--- a/features/modlog.js
+++ b/features/modlog.js
@@ -2,10 +2,12 @@ const { EmbedBuilder, PermissionsBitField } = require('discord.js');
 const { setModLogChannel, getModLogChannel } = require('../database');
 
 function register(client, commands) {
-  commands.set(
-    '!setmodlog',
-    '`!setmodlog <#channel>` - Set the channel where moderation actions are logged.'
-  );
+  commands.set('!setmodlog', {
+    description:
+      '`!setmodlog <#channel>` - Set the channel where moderation actions are logged.',
+    category: 'Moderation',
+    adminOnly: true
+  });
 
   const modLogChannels = new Map();
 

--- a/features/modmail.js
+++ b/features/modmail.js
@@ -14,13 +14,26 @@ const MAIN_GUILD_ID = '1165456303209054208';
 const activeTickets = new Map();
 
 function register(client, commands) {
-  commands.set('!claim', '`!claim` - Claim a modmail ticket.');
-  commands.set('!unclaim', '`!unclaim` - Unclaim the current ticket.');
-  commands.set('!close', '`!close` - Close the current ticket (assigned admin only).');
-  commands.set(
-    '!ticketlog',
-    '`!ticketlog <userId>` - Send the latest modmail log for a user.'
-  );
+  commands.set('!claim', {
+    description: '`!claim` - Claim a modmail ticket.',
+    category: 'Modmail',
+    adminOnly: true
+  });
+  commands.set('!unclaim', {
+    description: '`!unclaim` - Unclaim the current ticket.',
+    category: 'Modmail',
+    adminOnly: true
+  });
+  commands.set('!close', {
+    description: '`!close` - Close the current ticket (assigned admin only).',
+    category: 'Modmail',
+    adminOnly: true
+  });
+  commands.set('!ticketlog', {
+    description: '`!ticketlog <userId>` - Send the latest modmail log for a user.',
+    category: 'Modmail',
+    adminOnly: true
+  });
 
   // DM listener - open tickets and forward user messages
   client.on('messageCreate', async (message) => {

--- a/features/mute.js
+++ b/features/mute.js
@@ -20,8 +20,16 @@ function parseDuration(str) {
 }
 
 function register(client, commands) {
-  commands.set('!mute', '`!mute <@user|userId> <duration> [reason]` - Temporarily mute a user.');
-  commands.set('!unmute', '`!unmute <userId>` - Remove a mute from a user.');
+  commands.set('!mute', {
+    description: '`!mute <@user|userId> <duration> [reason]` - Temporarily mute a user.',
+    category: 'Moderation',
+    adminOnly: true
+  });
+  commands.set('!unmute', {
+    description: '`!unmute <userId>` - Remove a mute from a user.',
+    category: 'Moderation',
+    adminOnly: true
+  });
 
   client.on('messageCreate', async (message) => {
     try {

--- a/features/ping.js
+++ b/features/ping.js
@@ -1,5 +1,9 @@
 function register(client, commands) {
-  commands.set('!ping', '`!ping` - Check bot responsiveness.');
+  commands.set('!ping', {
+    description: '`!ping` - Check bot responsiveness.',
+    category: 'General',
+    adminOnly: false
+  });
 
   client.on('messageCreate', async (message) => {
     try {

--- a/features/warn.js
+++ b/features/warn.js
@@ -1,8 +1,16 @@
 const { addWarning, listWarnings } = require('../database');
 
 function register(client, commands) {
-  commands.set('!warn', '`!warn <@user|userId> [reason]` - Log a warning for a user.');
-  commands.set('!warnings', '`!warnings <userId>` - List warnings for a user.');
+  commands.set('!warn', {
+    description: '`!warn <@user|userId> [reason]` - Log a warning for a user.',
+    category: 'Moderation',
+    adminOnly: true
+  });
+  commands.set('!warnings', {
+    description: '`!warnings <userId>` - List warnings for a user.',
+    category: 'Moderation',
+    adminOnly: true
+  });
 
   client.on('messageCreate', async (message) => {
     try {


### PR DESCRIPTION
## Summary
- add metadata to command registry so each command includes description, category and adminOnly flag
- redesign help command to DM grouped embeds with playful colors and an admin-only section

## Testing
- `npm test`
- `node --check features/ping.js && node --check features/moderation.js && node --check features/birthdays.js && node --check features/modmail.js && node --check features/mute.js && node --check features/warn.js && node --check features/modlog.js && node --check features/help.js`


------
https://chatgpt.com/codex/tasks/task_e_689428344a20832ea3f30595586a8022