### PR TITLE
Log reputation transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ be set and exposes a `testMongoConnection()` function that pings the database.
 
 The bot re-applies active bans from the database on startup.
 
+## Mod-Log
+
+Use `!setmodlog #channel` to choose a channel for moderation logs. The bot records
+bans, unbans, kicks, mutes, warns, modmail ticket updates, and reputation
+transactions. Reputation entries show the giver, receiver, reason, and each
+user's new totals.
+
 ## Running
 
 Install dependencies and start the bot:

--- a/features/modlog.js
+++ b/features/modlog.js
@@ -70,8 +70,24 @@ function register(client, commands) {
         embed.addFields({ name: 'User', value: `<@${data.userId}>`, inline: true });
       if (data.moderatorId)
         embed.addFields({ name: 'Moderator', value: `<@${data.moderatorId}>`, inline: true });
+      if (data.fromUserId)
+        embed.addFields({ name: 'Giver', value: `<@${data.fromUserId}>`, inline: true });
+      if (data.toUserId)
+        embed.addFields({ name: 'Receiver', value: `<@${data.toUserId}>`, inline: true });
       if (data.duration)
         embed.addFields({ name: 'Duration', value: String(data.duration), inline: true });
+      if (data.giverTotal !== undefined)
+        embed.addFields({
+          name: 'Giver Total',
+          value: String(data.giverTotal),
+          inline: true
+        });
+      if (data.receiverTotal !== undefined)
+        embed.addFields({
+          name: 'Receiver Total',
+          value: String(data.receiverTotal),
+          inline: true
+        });
       if (data.reason) embed.addFields({ name: 'Reason', value: data.reason });
 
       await channel.send({ embeds: [embed] });
@@ -85,6 +101,9 @@ function register(client, commands) {
   client.on('kick', (data) => sendLog(data.guildId, 'Kick', data));
   client.on('mute', (data) => sendLog(data.guildId, 'Mute', data));
   client.on('warn', (data) => sendLog(data.guildId, 'Warn', data));
+  client.on('reputation', (data) =>
+    sendLog(data.guildId, 'Reputation', data)
+  );
 
   // Log modmail ticket opens and cancellations
   client.on('modmail', (data) =>

--- a/features/reputation.js
+++ b/features/reputation.js
@@ -64,6 +64,10 @@ function register(client, commands) {
           toUserId: user.id,
           reason
         });
+        const giverRep = await getReputation(
+          message.guild.id,
+          message.author.id
+        );
 
         let newBadge = null;
         for (const { name, points } of BADGE_THRESHOLDS) {
@@ -96,7 +100,9 @@ function register(client, commands) {
           guildId: message.guild.id,
           fromUserId: message.author.id,
           toUserId: user.id,
-          reason
+          reason,
+          giverTotal: giverRep.points,
+          receiverTotal: rep.points
         });
       }
 


### PR DESCRIPTION
## Summary
- log reputation transactions in mod-log with giver, receiver, reason and updated totals
- emit reputation events with both users' totals
- document that the mod-log records reputation transactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68942fccd890832eaddbba725a27782a