### PR TITLE
Add slash command modules

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -53,6 +53,7 @@ const client = new Client({
 client.prefixFeatures = prefixFeatures;
 client.slashFeatures = slashFeatures;
 client.features = prefixFeatures;
+client.commands = commands;
 
 // Allow each feature to register itself
 for (const feature of Object.values(prefixFeatures)) {
@@ -60,16 +61,17 @@ for (const feature of Object.values(prefixFeatures)) {
     feature.register(client, commands);
   }
 }
-
-// Allow slash features to register themselves
-for (const feature of Object.values(slashFeatures)) {
-  if (typeof feature.registerSlash === 'function') {
-    feature.registerSlash(client);
-  }
-}
-
 client.once('ready', async () => {
   console.log(`Logged in as ${client.user.tag}`);
+  for (const feature of Object.values(slashFeatures)) {
+    if (typeof feature.registerSlash === 'function') {
+      try {
+        await feature.registerSlash(client);
+      } catch (err) {
+        console.error('Failed to register slash feature:', err);
+      }
+    }
+  }
 });
 
 async function start() {

--- a/features/prefix/birthdays.js
+++ b/features/prefix/birthdays.js
@@ -282,4 +282,4 @@ function register(client, commands) {
   });
 }
 
-module.exports = { register };
+module.exports = { register, formatDate, parseDate, DATE_FORMATS };

--- a/features/prefix/moderation.js
+++ b/features/prefix/moderation.js
@@ -176,4 +176,4 @@ function register(client, commands) {
   });
 }
 
-module.exports = { register };
+module.exports = { register, banUser, unbanUser, explainBanQuery };

--- a/features/prefix/modmail.js
+++ b/features/prefix/modmail.js
@@ -315,5 +315,5 @@ function register(client, commands) {
   });
 }
 
-module.exports = { register };
+module.exports = { register, activeTickets };
 

--- a/features/prefix/mute.js
+++ b/features/prefix/mute.js
@@ -110,4 +110,4 @@ function register(client, commands) {
   });
 }
 
-module.exports = { register };
+module.exports = { register, parseDuration };

--- a/features/slash/birthdays.js
+++ b/features/slash/birthdays.js
@@ -1,0 +1,189 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const {
+  setBirthday,
+  clearBirthday,
+  listBirthdays,
+  setBirthdayChannel,
+  setBirthdayRole,
+  setBirthdayFormat,
+  getBirthdayFormat
+} = require('../../database');
+const {
+  formatDate,
+  parseDate,
+  DATE_FORMATS
+} = require('../prefix/birthdays');
+
+async function registerSlash(client) {
+  const setBirthdayCmd = new SlashCommandBuilder()
+    .setName('setbirthday')
+    .setDescription("Store your birthday using the server's format.")
+    .addStringOption((opt) =>
+      opt.setName('date').setDescription('Date of your birthday').setRequired(true)
+    );
+
+  const clearBirthdayCmd = new SlashCommandBuilder()
+    .setName('clearbirthday')
+    .setDescription('Remove your birthday.');
+
+  const listCmd = new SlashCommandBuilder()
+    .setName('birthdays')
+    .setDescription('List upcoming birthdays.');
+
+  const channelCmd = new SlashCommandBuilder()
+    .setName('setbirthdaychannel')
+    .setDescription('Set channel for birthday messages (ManageGuild).')
+    .addChannelOption((opt) =>
+      opt.setName('channel').setDescription('Channel').setRequired(true)
+    );
+
+  const roleCmd = new SlashCommandBuilder()
+    .setName('setbirthdayrole')
+    .setDescription('Set role assigned on birthdays (ManageGuild).')
+    .addRoleOption((opt) =>
+      opt.setName('role').setDescription('Role').setRequired(true)
+    );
+
+  const formatCmd = new SlashCommandBuilder()
+    .setName('setbirthdayformat')
+    .setDescription('Set birthday date format.')
+    .addStringOption((opt) =>
+      opt
+        .setName('format')
+        .setDescription(`Format (${DATE_FORMATS.join(', ')})`)
+        .setRequired(true)
+    );
+
+  if (client.commands) {
+    client.commands.set('/setbirthday', {
+      description: '`/setbirthday <date>` - store your birthday using the server\'s format.',
+      category: 'Birthdays',
+      adminOnly: false
+    });
+    client.commands.set('/clearbirthday', {
+      description: '`/clearbirthday` - remove your birthday.',
+      category: 'Birthdays',
+      adminOnly: false
+    });
+    client.commands.set('/birthdays', {
+      description: '`/birthdays` - list upcoming birthdays.',
+      category: 'Birthdays',
+      adminOnly: false
+    });
+    client.commands.set('/setbirthdaychannel', {
+      description: '`/setbirthdaychannel <#channel>` - set channel for birthday messages (ManageGuild).',
+      category: 'Birthdays',
+      adminOnly: true
+    });
+    client.commands.set('/setbirthdayrole', {
+      description: '`/setbirthdayrole <@role>` - set role assigned on birthdays (ManageGuild).',
+      category: 'Birthdays',
+      adminOnly: true
+    });
+    client.commands.set('/setbirthdayformat', {
+      description: `\`/setbirthdayformat <format>\` - set birthday date format. Formats: ${DATE_FORMATS.join(', ')} (ManageGuild).`,
+      category: 'Birthdays',
+      adminOnly: true
+    });
+  }
+
+  try {
+    await client.application.commands.create(setBirthdayCmd.toJSON());
+    await client.application.commands.create(clearBirthdayCmd.toJSON());
+    await client.application.commands.create(listCmd.toJSON());
+    await client.application.commands.create(channelCmd.toJSON());
+    await client.application.commands.create(roleCmd.toJSON());
+    await client.application.commands.create(formatCmd.toJSON());
+  } catch (err) {
+    console.error('Failed to register birthday slash commands:', err);
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      const { commandName } = interaction;
+      const format = await getBirthdayFormat(interaction.guildId);
+      if (commandName === 'setbirthday') {
+        const dateStr = interaction.options.getString('date', true);
+        const parsed = parseDate(dateStr, format || 'YYYY-MM-DD');
+        if (!parsed) {
+          return interaction.reply({
+            content: `Invalid date format. Expected ${format || 'YYYY-MM-DD'}.`,
+            ephemeral: true
+          });
+        }
+        await setBirthday(interaction.guildId, interaction.user.id, parsed);
+        await interaction.reply({ content: 'Birthday saved!', ephemeral: true });
+      } else if (commandName === 'clearbirthday') {
+        await clearBirthday(interaction.guildId, interaction.user.id);
+        await interaction.reply({ content: 'Birthday cleared.', ephemeral: true });
+      } else if (commandName === 'birthdays') {
+        const birthdays = await listBirthdays(interaction.guildId);
+        if (!birthdays.length) {
+          return interaction.reply('No birthdays recorded.');
+        }
+        const format = await getBirthdayFormat(interaction.guildId);
+        const months = Array.from({ length: 12 }, () => []);
+        for (const b of birthdays) {
+          const [year, month, day] = b.date.split('-').map(Number);
+          months[month - 1].push({ date: b.date, day, userId: b.userId });
+        }
+        const monthNames = [
+          'January',
+          'February',
+          'March',
+          'April',
+          'May',
+          'June',
+          'July',
+          'August',
+          'September',
+          'October',
+          'November',
+          'December'
+        ];
+        const lines = [];
+        for (let i = 0; i < months.length; i++) {
+          const arr = months[i].sort((a, b) => a.day - b.day);
+          if (!arr.length) continue;
+          lines.push(`**${monthNames[i]}**`);
+          for (const item of arr) {
+            lines.push(`${formatDate(item.date, format)} - <@${item.userId}>`);
+          }
+        }
+        await interaction.reply(lines.join('\n'));
+      } else if (commandName === 'setbirthdaychannel') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.ManageGuild)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const channel = interaction.options.getChannel('channel', true);
+        await setBirthdayChannel(interaction.guildId, channel.id);
+        await interaction.reply(`Birthday channel set to ${channel}.`);
+      } else if (commandName === 'setbirthdayrole') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.ManageGuild)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const role = interaction.options.getRole('role', true);
+        await setBirthdayRole(interaction.guildId, role.id);
+        await interaction.reply(`Birthday role set to ${role}.`);
+      } else if (commandName === 'setbirthdayformat') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.ManageGuild)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const fmt = interaction.options.getString('format', true);
+        if (!DATE_FORMATS.includes(fmt)) {
+          return interaction.reply({
+            content: `Format must be one of: ${DATE_FORMATS.join(', ')}`,
+            ephemeral: true
+          });
+        }
+        await setBirthdayFormat(interaction.guildId, fmt);
+        await interaction.reply(`Birthday format set to ${fmt}.`);
+      }
+    } catch (err) {
+      console.error('Error handling birthday slash command:', err);
+    }
+  });
+}
+
+module.exports = { registerSlash };

--- a/features/slash/help.js
+++ b/features/slash/help.js
@@ -1,0 +1,81 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+async function registerSlash(client) {
+  const data = new SlashCommandBuilder()
+    .setName('help')
+    .setDescription('Show available commands.');
+
+  if (client.commands) {
+    client.commands.set('/help', {
+      description: '`/help` - Show available commands.',
+      category: 'General',
+      adminOnly: false
+    });
+  }
+
+  try {
+    await client.application.commands.create(data.toJSON());
+  } catch (err) {
+    console.error('Failed to register /help:', err);
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      if (interaction.commandName !== 'help') return;
+
+      const commands = client.commands || new Map();
+      const categoryEmojis = {
+        General: '💬',
+        Birthdays: '🎂',
+        Modmail: '📬',
+        Moderation: '🛡️',
+        Reputation: '🏆'
+      };
+
+      const userCategories = new Map();
+      const adminCategories = new Map();
+      for (const [, info] of commands) {
+        const target = info.adminOnly ? adminCategories : userCategories;
+        if (!target.has(info.category)) target.set(info.category, []);
+        target.get(info.category).push(info.description);
+      }
+
+      const randomColor = () => Math.floor(Math.random() * 0xffffff);
+      const embeds = [];
+
+      if (userCategories.size) {
+        const embed = new EmbedBuilder()
+          .setTitle('Available Commands')
+          .setColor(randomColor());
+        for (const [cat, lines] of userCategories) {
+          const name = `${categoryEmojis[cat] ?? ''} ${cat}`.trim();
+          embed.addFields({ name, value: lines.join('\n') });
+        }
+        embeds.push(embed);
+      }
+
+      if (adminCategories.size) {
+        const embed = new EmbedBuilder()
+          .setTitle('ADMIN ONLY')
+          .setColor(randomColor());
+        for (const [cat, lines] of adminCategories) {
+          const name = `${categoryEmojis[cat] ?? ''} ${cat}`.trim();
+          embed.addFields({ name, value: lines.join('\n') });
+        }
+        embeds.push(embed);
+      }
+
+      try {
+        await interaction.user.send({ embeds });
+        await interaction.reply({ content: '📬 Check your DMs for the command list!', ephemeral: true });
+      } catch (err) {
+        await interaction.reply({ content: "❌ I couldn't send you the command list. Please enable DMs.", ephemeral: true });
+      }
+    } catch (err) {
+      console.error('Error handling /help command:', err);
+    }
+  });
+}
+
+module.exports = { registerSlash };

--- a/features/slash/moderation.js
+++ b/features/slash/moderation.js
@@ -1,0 +1,125 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const { banUser, unbanUser, explainBanQuery } = require('../prefix/moderation');
+
+async function registerSlash(client) {
+  const ban = new SlashCommandBuilder()
+    .setName('ban')
+    .setDescription('Ban a user and record the reason.')
+    .addUserOption((opt) =>
+      opt.setName('user').setDescription('User to ban').setRequired(true)
+    )
+    .addStringOption((opt) =>
+      opt.setName('reason').setDescription('Reason for ban').setRequired(false)
+    );
+
+  const kick = new SlashCommandBuilder()
+    .setName('kick')
+    .setDescription('Kick a user from the guild.')
+    .addUserOption((opt) =>
+      opt.setName('user').setDescription('User to kick').setRequired(true)
+    )
+    .addStringOption((opt) =>
+      opt.setName('reason').setDescription('Reason for kick').setRequired(false)
+    );
+
+  const unban = new SlashCommandBuilder()
+    .setName('unban')
+    .setDescription('Remove a ban from a user.')
+    .addStringOption((opt) =>
+      opt.setName('userid').setDescription('ID of user to unban').setRequired(true)
+    );
+
+  const banexplain = new SlashCommandBuilder()
+    .setName('banexplain')
+    .setDescription('Show MongoDB query stats for the ban collection.');
+
+  if (client.commands) {
+    client.commands.set('/ban', {
+      description: '`/ban <user> [reason]` - Ban a user and record the reason.',
+      category: 'Moderation',
+      adminOnly: true
+    });
+    client.commands.set('/kick', {
+      description: '`/kick <user> [reason]` - Kick a user from the guild.',
+      category: 'Moderation',
+      adminOnly: true
+    });
+    client.commands.set('/unban', {
+      description: '`/unban <userid>` - Remove a ban and unban the user.',
+      category: 'Moderation',
+      adminOnly: true
+    });
+    client.commands.set('/banexplain', {
+      description:
+        '`/banexplain` - *Admin only.* Show MongoDB query stats for the ban collection.',
+      category: 'Moderation',
+      adminOnly: true
+    });
+  }
+
+  try {
+    await client.application.commands.create(ban.toJSON());
+    await client.application.commands.create(kick.toJSON());
+    await client.application.commands.create(unban.toJSON());
+    await client.application.commands.create(banexplain.toJSON());
+  } catch (err) {
+    console.error('Failed to register moderation slash commands:', err);
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      const { commandName } = interaction;
+      if (commandName === 'ban') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.BanMembers)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const user = interaction.options.getUser('user', true);
+        const reason = interaction.options.getString('reason') || 'No reason provided';
+        try {
+          await banUser(client, interaction.guildId, user.id, reason);
+          await interaction.reply(`Banned ${user.tag}`);
+        } catch (err) {
+          console.error('Ban failed:', err);
+          await interaction.reply({ content: 'Failed to ban user.', ephemeral: true });
+        }
+      } else if (commandName === 'kick') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.KickMembers)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const user = interaction.options.getUser('user', true);
+        const reason = interaction.options.getString('reason') || 'No reason provided';
+        try {
+          await interaction.guild.members.kick(user.id, reason);
+          await interaction.reply(`Kicked ${user.tag}`);
+        } catch (err) {
+          console.error('Kick failed:', err);
+          await interaction.reply({ content: 'Failed to kick user.', ephemeral: true });
+        }
+      } else if (commandName === 'unban') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.BanMembers)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const userId = interaction.options.getString('userid', true);
+        try {
+          await unbanUser(client, interaction.guildId, userId);
+          await interaction.reply(`Unbanned <@${userId}>`);
+        } catch (err) {
+          console.error('Unban failed:', err);
+          await interaction.reply({ content: 'Failed to unban user.', ephemeral: true });
+        }
+      } else if (commandName === 'banexplain') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.Administrator)) {
+          return interaction.reply({ content: 'This command is restricted to administrators.', ephemeral: true });
+        }
+        await explainBanQuery(client, {
+          channel: { send: (msg) => interaction.reply(msg) }
+        });
+      }
+    } catch (err) {
+      console.error('Error handling moderation slash command:', err);
+    }
+  });
+}
+
+module.exports = { registerSlash };

--- a/features/slash/modmail.js
+++ b/features/slash/modmail.js
@@ -1,0 +1,164 @@
+const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+const { activeTickets } = require('../prefix/modmail');
+
+async function registerSlash(client) {
+  const claim = new SlashCommandBuilder()
+    .setName('claim')
+    .setDescription('Claim a modmail ticket.');
+
+  const unclaim = new SlashCommandBuilder()
+    .setName('unclaim')
+    .setDescription('Unclaim the current ticket.');
+
+  const close = new SlashCommandBuilder()
+    .setName('close')
+    .setDescription('Close the current ticket (assigned admin only).');
+
+  const ticketlog = new SlashCommandBuilder()
+    .setName('ticketlog')
+    .setDescription('Send the latest modmail log for a user.')
+    .addStringOption((opt) =>
+      opt.setName('userid').setDescription('User ID').setRequired(true)
+    );
+
+  if (client.commands) {
+    client.commands.set('/claim', {
+      description: '`/claim` - Claim a modmail ticket.',
+      category: 'Modmail',
+      adminOnly: true
+    });
+    client.commands.set('/unclaim', {
+      description: '`/unclaim` - Unclaim the current ticket.',
+      category: 'Modmail',
+      adminOnly: true
+    });
+    client.commands.set('/close', {
+      description: '`/close` - Close the current ticket (assigned admin only).',
+      category: 'Modmail',
+      adminOnly: true
+    });
+    client.commands.set('/ticketlog', {
+      description: '`/ticketlog <userId>` - Send the latest modmail log for a user.',
+      category: 'Modmail',
+      adminOnly: true
+    });
+  }
+
+  try {
+    await client.application.commands.create(claim.toJSON());
+    await client.application.commands.create(unclaim.toJSON());
+    await client.application.commands.create(close.toJSON());
+    await client.application.commands.create(ticketlog.toJSON());
+  } catch (err) {
+    console.error('Failed to register modmail slash commands:', err);
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      const { commandName } = interaction;
+      if (commandName === 'ticketlog') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.ManageGuild)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const targetId = interaction.options.getString('userid', true);
+        const logsDir = path.join(__dirname, '..', '..', 'ticket_logs');
+        try {
+          const files = fs
+            .readdirSync(logsDir)
+            .filter((f) => f.startsWith(`${targetId}-`));
+          if (!files.length) {
+            return interaction.reply('No ticket log exists for that user.');
+          }
+          const latest = files
+            .sort((a, b) => {
+              const tsA = parseInt(a.split('-')[1], 10);
+              const tsB = parseInt(b.split('-')[1], 10);
+              return tsB - tsA;
+            })[0];
+          const filePath = path.join(logsDir, latest);
+          let log;
+          try {
+            const raw = fs.readFileSync(filePath, 'utf8');
+            log = JSON.parse(raw);
+            if (!Array.isArray(log)) throw new Error('Malformed log');
+          } catch (err) {
+            return interaction.reply('Log file is missing or malformed.');
+          }
+          const lines = [];
+          for (const entry of log) {
+            const user = await client.users.fetch(entry.id).catch(() => null);
+            const tag = user ? user.tag : 'Unknown#0000';
+            const role = entry.from === 'admin' ? 'Admin' : 'User';
+            lines.push(`**${role} (${tag})**: ${entry.content}`);
+          }
+          const chunks = [];
+          let current = '';
+          for (const line of lines) {
+            if (current.length + line.length + 1 > 4096) {
+              chunks.push(current);
+              current = '';
+            }
+            current += (current ? '\n' : '') + line;
+          }
+          if (current) chunks.push(current);
+          const embeds = chunks.map((c) => new EmbedBuilder().setDescription(c));
+          await interaction.reply({ embeds, files: [filePath] });
+        } catch (err) {
+          await interaction.reply('No ticket log exists for that user.');
+        }
+        return;
+      }
+
+      // The rest commands operate within ticket channels
+      let userId = null;
+      for (const [uid, ticket] of activeTickets.entries()) {
+        if (ticket.channelId === interaction.channelId) {
+          userId = uid;
+          break;
+        }
+      }
+      if (!userId) return; // not in ticket channel
+
+      const ticket = activeTickets.get(userId);
+      if (commandName === 'claim') {
+        if (ticket.assignedAdminId && ticket.assignedAdminId !== interaction.user.id) {
+          await interaction.reply('Ticket already claimed.');
+        } else if (ticket.assignedAdminId === interaction.user.id) {
+          await interaction.reply('You have already claimed this ticket.');
+        } else {
+          ticket.assignedAdminId = interaction.user.id;
+          await interaction.reply(`Ticket claimed by <@${interaction.user.id}>.`);
+        }
+      } else if (commandName === 'unclaim') {
+        if (ticket.assignedAdminId !== interaction.user.id) {
+          await interaction.reply('You are not the assigned admin.');
+        } else {
+          ticket.assignedAdminId = null;
+          await interaction.reply('Ticket unclaimed.');
+        }
+      } else if (commandName === 'close') {
+        if (ticket.assignedAdminId !== interaction.user.id) {
+          await interaction.reply('You are not the assigned admin.');
+        } else {
+          const user = await client.users.fetch(userId);
+          await user.send('Your ticket has been closed.');
+          const logsDir = path.join(__dirname, '..', '..', 'ticket_logs');
+          fs.mkdirSync(logsDir, { recursive: true });
+          const filePath = path.join(logsDir, `${userId}-${Date.now()}.json`);
+          await fs.promises.writeFile(filePath, JSON.stringify(ticket.log, null, 2));
+          const channelId = interaction.channelId;
+          await interaction.channel.delete().catch(() => null);
+          activeTickets.delete(userId);
+          client.emit('modmail', { action: 'Closed', userId, channelId });
+        }
+      }
+    } catch (err) {
+      console.error('Error handling modmail slash command:', err);
+    }
+  });
+}
+
+module.exports = { registerSlash };

--- a/features/slash/mute.js
+++ b/features/slash/mute.js
@@ -1,0 +1,95 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const { addMute, removeMute } = require('../../database');
+const { parseDuration } = require('../prefix/mute');
+
+async function registerSlash(client) {
+  const mute = new SlashCommandBuilder()
+    .setName('mute')
+    .setDescription('Temporarily mute a user.')
+    .addUserOption((opt) =>
+      opt.setName('user').setDescription('User to mute').setRequired(true)
+    )
+    .addStringOption((opt) =>
+      opt.setName('duration').setDescription('Duration e.g. 10m, 1h').setRequired(true)
+    )
+    .addStringOption((opt) =>
+      opt.setName('reason').setDescription('Reason for mute').setRequired(false)
+    );
+
+  const unmute = new SlashCommandBuilder()
+    .setName('unmute')
+    .setDescription('Remove a mute from a user.')
+    .addStringOption((opt) =>
+      opt.setName('userid').setDescription('ID of user to unmute').setRequired(true)
+    );
+
+  if (client.commands) {
+    client.commands.set('/mute', {
+      description: '`/mute <user> <duration> [reason]` - Temporarily mute a user.',
+      category: 'Moderation',
+      adminOnly: true
+    });
+    client.commands.set('/unmute', {
+      description: '`/unmute <userid>` - Remove a mute from a user.',
+      category: 'Moderation',
+      adminOnly: true
+    });
+  }
+
+  try {
+    await client.application.commands.create(mute.toJSON());
+    await client.application.commands.create(unmute.toJSON());
+  } catch (err) {
+    console.error('Failed to register mute slash commands:', err);
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      const { commandName } = interaction;
+      if (commandName === 'mute') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.ModerateMembers)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const user = interaction.options.getUser('user', true);
+        const durationStr = interaction.options.getString('duration', true);
+        const duration = parseDuration(durationStr);
+        if (!duration) {
+          return interaction.reply({ content: 'Invalid duration. Use formats like `10m`, `1h`, etc.', ephemeral: true });
+        }
+        const reason = interaction.options.getString('reason') || 'No reason provided';
+        try {
+          const member = await interaction.guild.members.fetch(user.id);
+          await member.timeout(duration, reason);
+          await addMute({
+            userId: user.id,
+            guildId: interaction.guildId,
+            expiresAt: new Date(Date.now() + duration)
+          });
+          await interaction.reply(`Muted ${user.tag} for ${durationStr}.`);
+        } catch (err) {
+          console.error('Mute failed:', err);
+          await interaction.reply({ content: 'Failed to mute user.', ephemeral: true });
+        }
+      } else if (commandName === 'unmute') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.ModerateMembers)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const userId = interaction.options.getString('userid', true);
+        try {
+          const member = await interaction.guild.members.fetch(userId);
+          await member.timeout(null);
+          await removeMute(interaction.guildId, userId);
+          await interaction.reply(`Unmuted <@${userId}>.`);
+        } catch (err) {
+          console.error('Unmute failed:', err);
+          await interaction.reply({ content: 'Failed to unmute user.', ephemeral: true });
+        }
+      }
+    } catch (err) {
+      console.error('Error handling mute slash command:', err);
+    }
+  });
+}
+
+module.exports = { registerSlash };

--- a/features/slash/ping.js
+++ b/features/slash/ping.js
@@ -1,0 +1,33 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+async function registerSlash(client) {
+  const data = new SlashCommandBuilder()
+    .setName('ping')
+    .setDescription('Check bot responsiveness.');
+
+  if (client.commands) {
+    client.commands.set('/ping', {
+      description: '`/ping` - Check bot responsiveness.',
+      category: 'General',
+      adminOnly: false
+    });
+  }
+
+  try {
+    await client.application.commands.create(data.toJSON());
+  } catch (err) {
+    console.error('Failed to register /ping:', err);
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      if (interaction.commandName !== 'ping') return;
+      await interaction.reply('Pong!');
+    } catch (err) {
+      console.error('Error handling /ping command:', err);
+    }
+  });
+}
+
+module.exports = { registerSlash };

--- a/features/slash/reputation.js
+++ b/features/slash/reputation.js
@@ -1,0 +1,134 @@
+const { SlashCommandBuilder } = require('discord.js');
+const {
+  awardReputation,
+  getReputation,
+  getLastRepTimestamp,
+  addBadge
+} = require('../../database');
+
+const COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const BADGE_THRESHOLDS = [
+  { name: 'Bronze', points: 10 },
+  { name: 'Silver', points: 50 },
+  { name: 'Gold', points: 100 }
+];
+
+async function registerSlash(client) {
+  const rep = new SlashCommandBuilder()
+    .setName('rep')
+    .setDescription('Give a reputation point to a user.')
+    .addUserOption((opt) =>
+      opt.setName('user').setDescription('User to award').setRequired(true)
+    )
+    .addStringOption((opt) =>
+      opt.setName('reason').setDescription('Reason for awarding').setRequired(true)
+    );
+
+  const reputation = new SlashCommandBuilder()
+    .setName('reputation')
+    .setDescription("Show a user's reputation and badges.")
+    .addUserOption((opt) =>
+      opt.setName('user').setDescription('User to view').setRequired(false)
+    );
+
+  if (client.commands) {
+    client.commands.set('/rep', {
+      description: '`/rep @User <reason>` - Give a reputation point to a user.',
+      category: 'Reputation',
+      adminOnly: false
+    });
+    client.commands.set('/reputation', {
+      description: '`/reputation [@User]` - Show a user\'s reputation and badges.',
+      category: 'Reputation',
+      adminOnly: false
+    });
+  }
+
+  try {
+    await client.application.commands.create(rep.toJSON());
+    await client.application.commands.create(reputation.toJSON());
+  } catch (err) {
+    console.error('Failed to register reputation slash commands:', err);
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      const { commandName } = interaction;
+      if (commandName === 'rep') {
+        const user = interaction.options.getUser('user', true);
+        if (user.bot) {
+          return interaction.reply({ content: 'You cannot award reputation to bots.', ephemeral: true });
+        }
+        if (user.id === interaction.user.id) {
+          return interaction.reply({ content: 'You cannot award reputation to yourself.', ephemeral: true });
+        }
+        const reason = interaction.options.getString('reason', true);
+        const lastTimestamp = await getLastRepTimestamp(
+          interaction.guildId,
+          interaction.user.id,
+          user.id
+        );
+        if (lastTimestamp && Date.now() - new Date(lastTimestamp).getTime() < COOLDOWN_MS) {
+          return interaction.reply({
+            content: 'You can only award reputation to that user once every 24 hours.',
+            ephemeral: true
+          });
+        }
+        const rep = await awardReputation({
+          guildId: interaction.guildId,
+          fromUserId: interaction.user.id,
+          toUserId: user.id,
+          reason
+        });
+        const giverRep = await getReputation(
+          interaction.guildId,
+          interaction.user.id
+        );
+        let newBadge = null;
+        for (const { name, points } of BADGE_THRESHOLDS) {
+          if (rep.points >= points && !rep.badges.includes(name)) {
+            await addBadge(interaction.guildId, user.id, name);
+            newBadge = name;
+          }
+        }
+        await interaction.reply(
+          `Reputation point awarded to ${user}. They now have ${rep.points} point${
+            rep.points === 1 ? '' : 's'
+          }.`
+        );
+        if (newBadge) {
+          const member = await interaction.guild.members.fetch(user.id).catch(() => null);
+          if (member) {
+            member
+              .send(
+                `🎉 You have unlocked the **${newBadge}** reputation badge in ${interaction.guild.name}!`
+              )
+              .catch(() => {});
+          }
+        }
+        client.emit('reputation', {
+          guildId: interaction.guildId,
+          fromUserId: interaction.user.id,
+          toUserId: user.id,
+          reason,
+          giverTotal: giverRep.points,
+          receiverTotal: rep.points
+        });
+      } else if (commandName === 'reputation') {
+        const user = interaction.options.getUser('user') || interaction.user;
+        const rep = await getReputation(interaction.guildId, user.id);
+        const badges = rep.badges.length ? rep.badges.join(', ') : 'None';
+        await interaction.reply(
+          `${user} has ${rep.points} reputation point${
+            rep.points === 1 ? '' : 's'
+          }. Badges: ${badges}.`
+        );
+      }
+    } catch (err) {
+      console.error('Error handling reputation slash command:', err);
+    }
+  });
+}
+
+module.exports = { registerSlash };

--- a/features/slash/warn.js
+++ b/features/slash/warn.js
@@ -1,0 +1,82 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const { addWarning, listWarnings } = require('../../database');
+
+async function registerSlash(client) {
+  const warn = new SlashCommandBuilder()
+    .setName('warn')
+    .setDescription('Log a warning for a user.')
+    .addUserOption((opt) =>
+      opt.setName('user').setDescription('User to warn').setRequired(true)
+    )
+    .addStringOption((opt) =>
+      opt.setName('reason').setDescription('Reason for warning').setRequired(false)
+    );
+
+  const warnings = new SlashCommandBuilder()
+    .setName('warnings')
+    .setDescription('List warnings for a user.')
+    .addStringOption((opt) =>
+      opt.setName('userid').setDescription('ID of user to check').setRequired(true)
+    );
+
+  if (client.commands) {
+    client.commands.set('/warn', {
+      description: '`/warn <user> [reason]` - Log a warning for a user.',
+      category: 'Moderation',
+      adminOnly: true
+    });
+    client.commands.set('/warnings', {
+      description: '`/warnings <userid>` - List warnings for a user.',
+      category: 'Moderation',
+      adminOnly: true
+    });
+  }
+
+  try {
+    await client.application.commands.create(warn.toJSON());
+    await client.application.commands.create(warnings.toJSON());
+  } catch (err) {
+    console.error('Failed to register warn slash commands:', err);
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      const { commandName } = interaction;
+      if (commandName === 'warn') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.ModerateMembers)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const user = interaction.options.getUser('user', true);
+        const reason = interaction.options.getString('reason') || 'No reason provided';
+        await addWarning({ guildId: interaction.guildId, userId: user.id, reason });
+        await interaction.reply(`Warning recorded for ${user}: ${reason}`);
+        try {
+          const warnings = await listWarnings(interaction.guildId, user.id);
+          if (warnings.length >= 3) {
+            const member = await interaction.guild.members.fetch(user.id);
+            await member.timeout(10 * 60 * 1000, 'Auto-mute after 3 warnings');
+            await interaction.followUp({ content: `Auto-muted ${user} for repeated warnings.` });
+          }
+        } catch (err) {
+          console.error('Failed to check warnings:', err);
+        }
+      } else if (commandName === 'warnings') {
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.ModerateMembers)) {
+          return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+        }
+        const userId = interaction.options.getString('userid', true);
+        const warnings = await listWarnings(interaction.guildId, userId);
+        if (!warnings.length) {
+          return interaction.reply('No warnings found for that user.');
+        }
+        const lines = warnings.map((w, i) => `${i + 1}. ${w.reason} - ${w.createdAt.toISOString()}`);
+        await interaction.reply(`Warnings for <@${userId}>:\n${lines.join('\n')}`);
+      }
+    } catch (err) {
+      console.error('Error handling warn slash command:', err);
+    }
+  });
+}
+
+module.exports = { registerSlash };


### PR DESCRIPTION
## Summary
- add slash command implementations for ping, help, moderation, modmail, birthdays, mute, warn, and reputation features
- register slash commands after login using a shared command map
- expose helper functions from prefix features for reuse by slash modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689433a269c4832ea3d2a7520339b4b7