### PR TITLE
refactor: bulk register slash commands

### DIFF
--- a/features/slash/birthdays.js
+++ b/features/slash/birthdays.js
@@ -87,17 +87,6 @@ async function registerSlash(client) {
     });
   }
 
-  try {
-    await client.application.commands.create(setBirthdayCmd.toJSON());
-    await client.application.commands.create(clearBirthdayCmd.toJSON());
-    await client.application.commands.create(listCmd.toJSON());
-    await client.application.commands.create(channelCmd.toJSON());
-    await client.application.commands.create(roleCmd.toJSON());
-    await client.application.commands.create(formatCmd.toJSON());
-  } catch (err) {
-    console.error('Failed to register birthday slash commands:', err);
-  }
-
   client.on('interactionCreate', async (interaction) => {
     try {
       if (!interaction.isChatInputCommand()) return;
@@ -184,6 +173,15 @@ async function registerSlash(client) {
       console.error('Error handling birthday slash command:', err);
     }
   });
+
+  return [
+    setBirthdayCmd.toJSON(),
+    clearBirthdayCmd.toJSON(),
+    listCmd.toJSON(),
+    channelCmd.toJSON(),
+    roleCmd.toJSON(),
+    formatCmd.toJSON()
+  ];
 }
 
 module.exports = { registerSlash };

--- a/features/slash/help.js
+++ b/features/slash/help.js
@@ -13,12 +13,6 @@ async function registerSlash(client) {
     });
   }
 
-  try {
-    await client.application.commands.create(data.toJSON());
-  } catch (err) {
-    console.error('Failed to register /help:', err);
-  }
-
   client.on('interactionCreate', async (interaction) => {
     try {
       if (!interaction.isChatInputCommand()) return;
@@ -76,6 +70,8 @@ async function registerSlash(client) {
       console.error('Error handling /help command:', err);
     }
   });
+
+  return [data.toJSON()];
 }
 
 module.exports = { registerSlash };

--- a/features/slash/moderation.js
+++ b/features/slash/moderation.js
@@ -57,15 +57,6 @@ async function registerSlash(client) {
     });
   }
 
-  try {
-    await client.application.commands.create(ban.toJSON());
-    await client.application.commands.create(kick.toJSON());
-    await client.application.commands.create(unban.toJSON());
-    await client.application.commands.create(banexplain.toJSON());
-  } catch (err) {
-    console.error('Failed to register moderation slash commands:', err);
-  }
-
   client.on('interactionCreate', async (interaction) => {
     try {
       if (!interaction.isChatInputCommand()) return;
@@ -120,6 +111,8 @@ async function registerSlash(client) {
       console.error('Error handling moderation slash command:', err);
     }
   });
+
+  return [ban.toJSON(), kick.toJSON(), unban.toJSON(), banexplain.toJSON()];
 }
 
 module.exports = { registerSlash };

--- a/features/slash/modmail.js
+++ b/features/slash/modmail.js
@@ -46,15 +46,6 @@ async function registerSlash(client) {
     });
   }
 
-  try {
-    await client.application.commands.create(claim.toJSON());
-    await client.application.commands.create(unclaim.toJSON());
-    await client.application.commands.create(close.toJSON());
-    await client.application.commands.create(ticketlog.toJSON());
-  } catch (err) {
-    console.error('Failed to register modmail slash commands:', err);
-  }
-
   client.on('interactionCreate', async (interaction) => {
     try {
       if (!interaction.isChatInputCommand()) return;
@@ -159,6 +150,8 @@ async function registerSlash(client) {
       console.error('Error handling modmail slash command:', err);
     }
   });
+
+  return [claim.toJSON(), unclaim.toJSON(), close.toJSON(), ticketlog.toJSON()];
 }
 
 module.exports = { registerSlash };

--- a/features/slash/mute.js
+++ b/features/slash/mute.js
@@ -36,13 +36,6 @@ async function registerSlash(client) {
     });
   }
 
-  try {
-    await client.application.commands.create(mute.toJSON());
-    await client.application.commands.create(unmute.toJSON());
-  } catch (err) {
-    console.error('Failed to register mute slash commands:', err);
-  }
-
   client.on('interactionCreate', async (interaction) => {
     try {
       if (!interaction.isChatInputCommand()) return;
@@ -90,6 +83,8 @@ async function registerSlash(client) {
       console.error('Error handling mute slash command:', err);
     }
   });
+
+  return [mute.toJSON(), unmute.toJSON()];
 }
 
 module.exports = { registerSlash };

--- a/features/slash/ping.js
+++ b/features/slash/ping.js
@@ -13,12 +13,6 @@ async function registerSlash(client) {
     });
   }
 
-  try {
-    await client.application.commands.create(data.toJSON());
-  } catch (err) {
-    console.error('Failed to register /ping:', err);
-  }
-
   client.on('interactionCreate', async (interaction) => {
     try {
       if (!interaction.isChatInputCommand()) return;
@@ -28,6 +22,8 @@ async function registerSlash(client) {
       console.error('Error handling /ping command:', err);
     }
   });
+
+  return [data.toJSON()];
 }
 
 module.exports = { registerSlash };

--- a/features/slash/reputation.js
+++ b/features/slash/reputation.js
@@ -44,13 +44,6 @@ async function registerSlash(client) {
     });
   }
 
-  try {
-    await client.application.commands.create(rep.toJSON());
-    await client.application.commands.create(reputation.toJSON());
-  } catch (err) {
-    console.error('Failed to register reputation slash commands:', err);
-  }
-
   client.on('interactionCreate', async (interaction) => {
     try {
       if (!interaction.isChatInputCommand()) return;
@@ -129,6 +122,8 @@ async function registerSlash(client) {
       console.error('Error handling reputation slash command:', err);
     }
   });
+
+  return [rep.toJSON(), reputation.toJSON()];
 }
 
 module.exports = { registerSlash };

--- a/features/slash/warn.js
+++ b/features/slash/warn.js
@@ -32,13 +32,6 @@ async function registerSlash(client) {
     });
   }
 
-  try {
-    await client.application.commands.create(warn.toJSON());
-    await client.application.commands.create(warnings.toJSON());
-  } catch (err) {
-    console.error('Failed to register warn slash commands:', err);
-  }
-
   client.on('interactionCreate', async (interaction) => {
     try {
       if (!interaction.isChatInputCommand()) return;
@@ -77,6 +70,8 @@ async function registerSlash(client) {
       console.error('Error handling warn slash command:', err);
     }
   });
+
+  return [warn.toJSON(), warnings.toJSON()];
 }
 
 module.exports = { registerSlash };


### PR DESCRIPTION
## Summary
- gather slash command payloads from modules and bulk register via REST
- support guild-scoped registration in development and global registration in production

## Testing
- `npm test`
- `for f in features/slash/*.js; do node --check $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68943762e868832ea483e0350224600f