### PR TITLE
Add anti-raid configuration and logging

### DIFF
--- a/database/antiRaid.js
+++ b/database/antiRaid.js
@@ -1,0 +1,101 @@
+const DEFAULT_JOIN_THRESHOLD = { count: 5, seconds: 10 };
+const DEFAULT_MSG_THRESHOLD = 5;
+
+let antiRaidSettings;
+let antiRaidEvents;
+
+function ensureSettings() {
+  if (!antiRaidSettings) {
+    console.warn('AntiRaidSettings collection is not initialized. Call init() first.');
+    throw new Error('Database not initialized');
+  }
+}
+
+function ensureEvents() {
+  if (!antiRaidEvents) {
+    console.warn('AntiRaidEvents collection is not initialized. Call init() first.');
+    throw new Error('Database not initialized');
+  }
+}
+
+function init(db) {
+  antiRaidSettings = db.collection('antiRaidSettings');
+  antiRaidEvents = db.collection('antiRaidEvents');
+}
+
+async function getAntiRaidSettings(guildId) {
+  ensureSettings();
+  const doc = await antiRaidSettings.findOne({ guildId });
+  if (!doc) {
+    return {
+      guildId,
+      joinThreshold: { ...DEFAULT_JOIN_THRESHOLD },
+      msgThreshold: DEFAULT_MSG_THRESHOLD,
+      whitelist: [],
+      verifyQuestion: null
+    };
+  }
+  return doc;
+}
+
+async function setJoinThreshold(guildId, count, seconds) {
+  ensureSettings();
+  await antiRaidSettings.updateOne(
+    { guildId },
+    { $set: { guildId, joinThreshold: { count, seconds } } },
+    { upsert: true }
+  );
+}
+
+async function setMsgThreshold(guildId, count) {
+  ensureSettings();
+  await antiRaidSettings.updateOne(
+    { guildId },
+    { $set: { guildId, msgThreshold: count } },
+    { upsert: true }
+  );
+}
+
+async function addWhitelistDomain(guildId, domain) {
+  ensureSettings();
+  await antiRaidSettings.updateOne(
+    { guildId },
+    { $addToSet: { whitelist: domain } },
+    { upsert: true }
+  );
+}
+
+async function removeWhitelistDomain(guildId, domain) {
+  ensureSettings();
+  await antiRaidSettings.updateOne(
+    { guildId },
+    { $pull: { whitelist: domain } }
+  );
+}
+
+async function setVerifyQuestion(guildId, question, answer) {
+  ensureSettings();
+  await antiRaidSettings.updateOne(
+    { guildId },
+    { $set: { guildId, verifyQuestion: { question, answer } } },
+    { upsert: true }
+  );
+}
+
+async function logAntiRaidEvent(guildId, type, details) {
+  ensureEvents();
+  const doc = { guildId, type, details, createdAt: new Date() };
+  await antiRaidEvents.insertOne(doc);
+  return doc;
+}
+
+module.exports = {
+  init,
+  getAntiRaidSettings,
+  setJoinThreshold,
+  setMsgThreshold,
+  addWhitelistDomain,
+  removeWhitelistDomain,
+  setVerifyQuestion,
+  logAntiRaidEvent
+};

--- a/database/index.js
+++ b/database/index.js
@@ -12,6 +12,8 @@ let guildSettings;
 let birthdays;
 let reputations;
 let repTransactions;
+// Anti-raid collections
+const antiRaid = require('./antiRaid');
 
 const DEFAULT_BIRTHDAY_FORMAT = 'YYYY-MM-DD';
 
@@ -81,6 +83,8 @@ async function init() {
     birthdays = db.collection('birthdays');
     reputations = db.collection('reputations');
     repTransactions = db.collection('repTransactions');
+    // initialize anti-raid collections
+    antiRaid.init(db);
     console.log('Connected to MongoDB');
   } catch (err) {
     console.error('MongoDB connection error:', err);
@@ -309,5 +313,7 @@ module.exports = {
   getReputation,
   getLastRepTimestamp,
   addBadge,
-  close
+  close,
+  // anti-raid helpers
+  ...antiRaid
 };

--- a/features/prefix/antiRaid.js
+++ b/features/prefix/antiRaid.js
@@ -1,0 +1,134 @@
+const crypto = require('crypto');
+const {
+  getAntiRaidSettings,
+  logAntiRaidEvent
+} = require('../../database');
+
+const joinTimestamps = new Map();
+const memberJoinTimes = new Map();
+const messageTimestamps = new Map();
+const recentHashes = new Map();
+
+async function handleGuildMemberAdd(member) {
+  try {
+    const guildId = member.guild.id;
+    const settings = await getAntiRaidSettings(guildId);
+    const now = Date.now();
+    let joins = joinTimestamps.get(guildId);
+    if (!joins) {
+      joins = [];
+      joinTimestamps.set(guildId, joins);
+    }
+    joins.push(now);
+    const window = (settings.joinThreshold?.seconds || 10) * 1000;
+    while (joins.length && now - joins[0] > window) joins.shift();
+    if (settings.joinThreshold && joins.length >= settings.joinThreshold.count) {
+      member.client.emit('antiRaidJoinSpike', { guild: member.guild, count: joins.length });
+      await logAntiRaidEvent(guildId, 'joinSpike', { count: joins.length });
+    }
+    let guildMap = memberJoinTimes.get(guildId);
+    if (!guildMap) {
+      guildMap = new Map();
+      memberJoinTimes.set(guildId, guildMap);
+    }
+    guildMap.set(member.id, now);
+  } catch (err) {
+    console.error('antiRaid guildMemberAdd error:', err);
+  }
+}
+
+function extractDomains(content) {
+  const matches = content.match(/https?:\/\/[^\s]+/gi) || [];
+  const domains = [];
+  for (const url of matches) {
+    try {
+      const d = new URL(url).hostname.replace(/^www\./, '');
+      domains.push(d);
+    } catch (e) {
+      // ignore
+    }
+  }
+  return domains;
+}
+
+async function handleMessage(message) {
+  try {
+    if (message.author.bot || !message.guild) return;
+    const guildId = message.guild.id;
+    const now = Date.now();
+    const settings = await getAntiRaidSettings(guildId);
+    const joinMap = memberJoinTimes.get(guildId);
+    const joinTime = joinMap ? joinMap.get(message.author.id) : null;
+    const isNew = joinTime && now - joinTime < 10 * 60 * 1000;
+    if (!isNew) return;
+
+    let guildMsgs = messageTimestamps.get(guildId);
+    if (!guildMsgs) {
+      guildMsgs = new Map();
+      messageTimestamps.set(guildId, guildMsgs);
+    }
+    let timestamps = guildMsgs.get(message.author.id);
+    if (!timestamps) {
+      timestamps = [];
+      guildMsgs.set(message.author.id, timestamps);
+    }
+    timestamps.push(now);
+    while (timestamps.length && now - timestamps[0] > 5000) timestamps.shift();
+    if (settings.msgThreshold && timestamps.length > settings.msgThreshold) {
+      message.client.emit('antiRaidSpamDetected', { guild: message.guild, user: message.author });
+      await logAntiRaidEvent(guildId, 'msgSpike', {
+        userId: message.author.id,
+        count: timestamps.length
+      });
+    }
+
+    const domains = extractDomains(message.content || '');
+    for (const domain of domains) {
+      if (!settings.whitelist || !settings.whitelist.includes(domain)) {
+        await logAntiRaidEvent(guildId, 'filteredInvite', {
+          userId: message.author.id,
+          domain
+        });
+        message.delete().catch(() => {});
+        return;
+      }
+    }
+
+    const content = message.content || '';
+    if (content) {
+      const hash = crypto.createHash('sha1').update(content).digest('hex');
+      let guildHashes = recentHashes.get(guildId);
+      if (!guildHashes) {
+        guildHashes = new Map();
+        recentHashes.set(guildId, guildHashes);
+      }
+      let entry = guildHashes.get(hash);
+      if (!entry || now - entry.timestamp > 30000) {
+        entry = { users: new Set([message.author.id]), timestamp: now };
+        guildHashes.set(hash, entry);
+      } else {
+        entry.users.add(message.author.id);
+        entry.timestamp = now;
+        if (entry.users.size > 1) {
+          message.client.emit('antiRaidSpamDetected', {
+            guild: message.guild,
+            hash
+          });
+          await logAntiRaidEvent(guildId, 'duplicateContent', {
+            hash,
+            users: Array.from(entry.users)
+          });
+        }
+      }
+    }
+  } catch (err) {
+    console.error('antiRaid messageCreate error:', err);
+  }
+}
+
+function register(client) {
+  client.on('guildMemberAdd', handleGuildMemberAdd);
+  client.on('messageCreate', handleMessage);
+}
+
+module.exports = { register };

--- a/features/slash/antiRaid.js
+++ b/features/slash/antiRaid.js
@@ -1,0 +1,133 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const {
+  setJoinThreshold,
+  setMsgThreshold,
+  addWhitelistDomain,
+  removeWhitelistDomain,
+  setVerifyQuestion
+} = require('../../database');
+
+async function registerSlash(client) {
+  const cmd = new SlashCommandBuilder()
+    .setName('antiraid')
+    .setDescription('Configure anti-raid settings')
+    .addSubcommandGroup((group) =>
+      group
+        .setName('set')
+        .setDescription('Set thresholds')
+        .addSubcommand((sub) =>
+          sub
+            .setName('join-threshold')
+            .setDescription('Set join spike threshold')
+            .addIntegerOption((opt) =>
+              opt.setName('count').setDescription('Join count').setRequired(true)
+            )
+            .addIntegerOption((opt) =>
+              opt
+                .setName('seconds')
+                .setDescription('Time window in seconds')
+                .setRequired(true)
+            )
+        )
+        .addSubcommand((sub) =>
+          sub
+            .setName('msg-threshold')
+            .setDescription('Set message spam threshold')
+            .addIntegerOption((opt) =>
+              opt.setName('count').setDescription('Message count').setRequired(true)
+            )
+        )
+    )
+    .addSubcommandGroup((group) =>
+      group
+        .setName('whitelist')
+        .setDescription('Manage link whitelist')
+        .addSubcommand((sub) =>
+          sub
+            .setName('add')
+            .setDescription('Add domain to whitelist')
+            .addStringOption((opt) =>
+              opt.setName('domain').setDescription('Domain').setRequired(true)
+            )
+        )
+        .addSubcommand((sub) =>
+          sub
+            .setName('remove')
+            .setDescription('Remove domain from whitelist')
+            .addStringOption((opt) =>
+              opt.setName('domain').setDescription('Domain').setRequired(true)
+            )
+        )
+    )
+    .addSubcommandGroup((group) =>
+      group
+        .setName('verify-question')
+        .setDescription('Verification question')
+        .addSubcommand((sub) =>
+          sub
+            .setName('set')
+            .setDescription('Set verification question')
+            .addStringOption((opt) =>
+              opt.setName('question').setDescription('Question').setRequired(true)
+            )
+            .addStringOption((opt) =>
+              opt.setName('answer').setDescription('Answer').setRequired(true)
+            )
+        )
+    );
+
+  if (client.commands) {
+    client.commands.set('/antiraid', {
+      description: '`/antiraid` - Configure anti-raid settings.',
+      category: 'Moderation',
+      adminOnly: true
+    });
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      if (interaction.commandName !== 'antiraid') return;
+      if (!interaction.memberPermissions.has(PermissionsBitField.Flags.ManageGuild)) {
+        return interaction.reply({ content: 'You do not have permission to use this command.', ephemeral: true });
+      }
+      const group = interaction.options.getSubcommandGroup();
+      const sub = interaction.options.getSubcommand();
+      const guildId = interaction.guildId;
+      if (group === 'set' && sub === 'join-threshold') {
+        const count = interaction.options.getInteger('count', true);
+        const seconds = interaction.options.getInteger('seconds', true);
+        await setJoinThreshold(guildId, count, seconds);
+        await interaction.reply(`Join threshold set to ${count} joins in ${seconds} seconds.`);
+      } else if (group === 'set' && sub === 'msg-threshold') {
+        const count = interaction.options.getInteger('count', true);
+        await setMsgThreshold(guildId, count);
+        await interaction.reply(`Message threshold set to ${count} messages/5s.`);
+      } else if (group === 'whitelist' && sub === 'add') {
+        const domain = interaction.options.getString('domain', true);
+        await addWhitelistDomain(guildId, domain);
+        await interaction.reply(`Added \`${domain}\` to whitelist.`);
+      } else if (group === 'whitelist' && sub === 'remove') {
+        const domain = interaction.options.getString('domain', true);
+        await removeWhitelistDomain(guildId, domain);
+        await interaction.reply(`Removed \`${domain}\` from whitelist.`);
+      } else if (group === 'verify-question' && sub === 'set') {
+        const question = interaction.options.getString('question', true);
+        const answer = interaction.options.getString('answer', true);
+        await setVerifyQuestion(guildId, question, answer);
+        await interaction.reply('Verification question set.');
+      }
+    } catch (err) {
+      console.error('Error handling antiraid slash command:', err);
+      if (interaction.isRepliable()) {
+        try {
+          await interaction.reply({ content: 'Failed to update anti-raid settings.', ephemeral: true });
+        } catch (_) {}
+      }
+    }
+  });
+
+  return [cmd.toJSON()];
+}
+
+module.exports = { registerSlash };


### PR DESCRIPTION
## Summary
- store anti-raid thresholds, whitelists and verification questions in new database helpers
- track join/message spikes, unauthorized links and duplicate content
- expose `/antiraid` slash command to configure thresholds and whitelist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68943c14ca98832e9b09ea470f0d0aef