### PR TITLE
Guard anti-raid init and pass db instance

### DIFF
--- a/database/antiRaid.js
+++ b/database/antiRaid.js
@@ -19,6 +19,7 @@ function ensureEvents() {
 }
 
 function init(db) {
+  if (!db) throw new Error('antiRaid.init called without db');
   antiRaidSettings = db.collection('antiRaidSettings');
   antiRaidEvents = db.collection('antiRaidEvents');
 }

--- a/database/index.js
+++ b/database/index.js
@@ -14,6 +14,7 @@ let reputations;
 let repTransactions;
 // Anti-raid collections
 const antiRaid = require('./antiRaid');
+const { init: initAntiRaid, ...antiRaidHelpers } = antiRaid;
 
 const DEFAULT_BIRTHDAY_FORMAT = 'YYYY-MM-DD';
 
@@ -84,7 +85,7 @@ async function init() {
     reputations = db.collection('reputations');
     repTransactions = db.collection('repTransactions');
     // initialize anti-raid collections
-    antiRaid.init(db);
+    initAntiRaid(db); // must supply the db instance
     console.log('Connected to MongoDB');
   } catch (err) {
     console.error('MongoDB connection error:', err);
@@ -315,5 +316,5 @@ module.exports = {
   addBadge,
   close,
   // anti-raid helpers
-  ...antiRaid
+  ...antiRaidHelpers
 };


### PR DESCRIPTION
## Summary
- Pass MongoDB database handle into anti-raid initializer and prevent export conflicts
- Validate `antiRaid.init` receives a db parameter

## Testing
- `npm test`
- `DISCORD_BOT_TOKEN="dummy" MONGODB_URI="mongodb://127.0.0.1:27017/test" npm start` *(fails: connect ECONNREFUSED 127.0.0.1:27017)*


------
https://chatgpt.com/codex/tasks/task_e_68943e0c6ce0832e85f2de8fadbfb063