### PR TITLE
Increase message listener limit

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -50,6 +50,11 @@ const client = new Client({
   ]
 });
 
+// Increase the default maximum number of listeners for shared events.
+// This avoids Node's memory leak warnings when multiple features attach
+// `messageCreate` handlers during startup.
+client.setMaxListeners(20);
+
 client.prefixFeatures = prefixFeatures;
 client.slashFeatures = slashFeatures;
 client.features = prefixFeatures;


### PR DESCRIPTION
## Summary
- raise max listener count to accommodate multiple messageCreate features

## Testing
- `npm test`
- `node - <<'NODE' ... (listener count)`

------
https://chatgpt.com/codex/tasks/task_e_6894402dadfc832e9468d8466d4e802e