### PR TITLE
Add economy model and balance helpers

### DIFF
--- a/database/economyModel.js
+++ b/database/economyModel.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const economySchema = new mongoose.Schema({
+  guildId: { type: String, required: true },
+  userId: { type: String, required: true },
+  balance: { type: Number, default: 0 }
+});
+
+economySchema.index({ guildId: 1, userId: 1 }, { unique: true });
+
+module.exports = mongoose.model('Economy', economySchema);


### PR DESCRIPTION
## Summary
- Add `Economy` Mongoose model with compound guild/user index for balances.
- Introduce economy collection to database init and helper functions to fetch and increment balances atomically.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894e908344c832e9ac9a4cb5b981173