### PR TITLE
feat: add economy balance and work commands

### DIFF
--- a/database/economyModel.js
+++ b/database/economyModel.js
@@ -3,7 +3,8 @@ const mongoose = require('mongoose');
 const economySchema = new mongoose.Schema({
   guildId: { type: String, required: true },
   userId: { type: String, required: true },
-  balance: { type: Number, default: 0 }
+  balance: { type: Number, default: 0 },
+  lastWork: { type: Date }
 });
 
 economySchema.index({ guildId: 1, userId: 1 }, { unique: true });

--- a/database/index.js
+++ b/database/index.js
@@ -307,6 +307,21 @@ async function incrementBalance(guildId, userId, amount) {
   return updateResult.value.balance;
 }
 
+async function getLastWorkTimestamp(guildId, userId) {
+  ensureEconomy();
+  const doc = await economy.findOne({ guildId, userId });
+  return doc ? doc.lastWork || null : null;
+}
+
+async function setLastWorkTimestamp(guildId, userId, timestamp = new Date()) {
+  ensureEconomy();
+  await economy.updateOne(
+    { guildId, userId },
+    { $set: { lastWork: timestamp }, $setOnInsert: { balance: 0 } },
+    { upsert: true }
+  );
+}
+
 async function close() {
   await client.close();
 }
@@ -341,6 +356,8 @@ module.exports = {
   addBadge,
   getBalance,
   incrementBalance,
+  getLastWorkTimestamp,
+  setLastWorkTimestamp,
   close,
   // anti-raid helpers
   ...antiRaidHelpers

--- a/features/prefix/economy.js
+++ b/features/prefix/economy.js
@@ -1,0 +1,49 @@
+const { getBalance, incrementBalance, getLastWorkTimestamp, setLastWorkTimestamp } = require('../../database');
+
+const COOLDOWN_MS = 60 * 60 * 1000;
+
+function register(client, commands) {
+  commands.set('!balance', {
+    description: '`!balance` - Display your current balance.',
+    category: 'Economy',
+    adminOnly: false
+  });
+  commands.set('!work', {
+    description: '`!work` - Work to earn a random amount once per hour.',
+    category: 'Economy',
+    adminOnly: false
+  });
+
+  client.on('messageCreate', async (message) => {
+    try {
+      if (message.author.bot) return;
+      if (!message.guild) return;
+      if (!message.content.startsWith('!')) return;
+
+      const args = message.content.trim().split(/\s+/);
+      const command = args.shift().toLowerCase();
+
+      if (command === '!balance') {
+        const balance = await getBalance(message.guild.id, message.author.id);
+        return message.reply(`Your balance is ${balance}.`);
+      }
+
+      if (command === '!work') {
+        const last = await getLastWorkTimestamp(message.guild.id, message.author.id);
+        if (last && Date.now() - new Date(last).getTime() < COOLDOWN_MS) {
+          const remaining = COOLDOWN_MS - (Date.now() - new Date(last).getTime());
+          const minutes = Math.ceil(remaining / 60000);
+          return message.reply(`You can work again in ${minutes} minute${minutes === 1 ? '' : 's'}.`);
+        }
+        const amount = Math.floor(Math.random() * 101) + 50;
+        const balance = await incrementBalance(message.guild.id, message.author.id, amount);
+        await setLastWorkTimestamp(message.guild.id, message.author.id);
+        return message.reply(`You earned ${amount} coins. Your balance is now ${balance}.`);
+      }
+    } catch (err) {
+      console.error('Error handling economy commands:', err);
+    }
+  });
+}
+
+module.exports = { register };

--- a/features/slash/economy.js
+++ b/features/slash/economy.js
@@ -1,0 +1,57 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { getBalance, incrementBalance, getLastWorkTimestamp, setLastWorkTimestamp } = require('../../database');
+
+const COOLDOWN_MS = 60 * 60 * 1000;
+
+async function registerSlash(client) {
+  const balance = new SlashCommandBuilder()
+    .setName('balance')
+    .setDescription('Display your current balance.');
+
+  const work = new SlashCommandBuilder()
+    .setName('work')
+    .setDescription('Work to earn a random amount once per hour.');
+
+  if (client.commands) {
+    client.commands.set('/balance', {
+      description: '`/balance` - Display your current balance.',
+      category: 'Economy',
+      adminOnly: false
+    });
+    client.commands.set('/work', {
+      description: '`/work` - Work to earn a random amount once per hour.',
+      category: 'Economy',
+      adminOnly: false
+    });
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      if (interaction.commandName === 'balance') {
+        const bal = await getBalance(interaction.guildId, interaction.user.id);
+        await interaction.reply(`Your balance is ${bal}.`);
+      } else if (interaction.commandName === 'work') {
+        const last = await getLastWorkTimestamp(interaction.guildId, interaction.user.id);
+        if (last && Date.now() - new Date(last).getTime() < COOLDOWN_MS) {
+          const remaining = COOLDOWN_MS - (Date.now() - new Date(last).getTime());
+          const minutes = Math.ceil(remaining / 60000);
+          return interaction.reply({
+            content: `You can work again in ${minutes} minute${minutes === 1 ? '' : 's'}.`,
+            ephemeral: true
+          });
+        }
+        const amount = Math.floor(Math.random() * 101) + 50;
+        const bal = await incrementBalance(interaction.guildId, interaction.user.id, amount);
+        await setLastWorkTimestamp(interaction.guildId, interaction.user.id);
+        await interaction.reply(`You earned ${amount} coins. Your balance is now ${bal}.`);
+      }
+    } catch (err) {
+      console.error('Error handling economy slash commands:', err);
+    }
+  });
+
+  return [balance.toJSON(), work.toJSON()];
+}
+
+module.exports = { registerSlash };


### PR DESCRIPTION
## Summary
- add database helpers to track `work` cooldowns and balances
- implement `balance` and `work` commands for prefix and slash

## Testing
- `npm test`
- `node --check features/prefix/economy.js`
- `node --check features/slash/economy.js`


------
https://chatgpt.com/codex/tasks/task_e_6894ed12b69c832e95f080089e94143c