### PR TITLE
feat: add slots command to economy

### DIFF
--- a/features/prefix/economy.js
+++ b/features/prefix/economy.js
@@ -1,3 +1,5 @@
+const { EmbedBuilder } = require('discord.js');
+const crypto = require('crypto');
 const { getBalance, incrementBalance, getLastWorkTimestamp, setLastWorkTimestamp } = require('../../database');
 
 const COOLDOWN_MS = 60 * 60 * 1000;
@@ -10,6 +12,11 @@ function register(client, commands) {
   });
   commands.set('!work', {
     description: '`!work` - Work to earn a random amount once per hour.',
+    category: 'Economy',
+    adminOnly: false
+  });
+  commands.set('!slots <bet>', {
+    description: '`!slots <bet>` - Bet on a slot machine to win coins.',
     category: 'Economy',
     adminOnly: false
   });
@@ -39,6 +46,51 @@ function register(client, commands) {
         const balance = await incrementBalance(message.guild.id, message.author.id, amount);
         await setLastWorkTimestamp(message.guild.id, message.author.id);
         return message.reply(`You earned ${amount} coins. Your balance is now ${balance}.`);
+      }
+
+      if (command === '!slots') {
+        const bet = parseInt(args[0], 10);
+        if (isNaN(bet) || bet <= 0) {
+          return message.reply('Please provide a valid bet amount.');
+        }
+        const current = await getBalance(message.guild.id, message.author.id);
+        if (current < bet) {
+          return message.reply('You do not have enough coins for that bet.');
+        }
+
+        await incrementBalance(message.guild.id, message.author.id, -bet);
+
+        const symbols = ['🍒', '🍋', '🍊', '🍇', '⭐'];
+        const spin = [
+          symbols[crypto.randomInt(symbols.length)],
+          symbols[crypto.randomInt(symbols.length)],
+          symbols[crypto.randomInt(symbols.length)]
+        ];
+
+        let payout = 0;
+        if (spin[0] === spin[1] && spin[1] === spin[2]) {
+          payout = bet * 10;
+        } else if (spin[0] === spin[1] || spin[0] === spin[2] || spin[1] === spin[2]) {
+          payout = bet * 2;
+        }
+
+        if (payout > 0) {
+          await incrementBalance(message.guild.id, message.author.id, payout);
+        }
+        const balance = await getBalance(message.guild.id, message.author.id);
+
+        const embed = new EmbedBuilder()
+          .setTitle('Slots')
+          .addFields(
+            { name: 'Result', value: spin.join(' '), inline: false },
+            {
+              name: 'Outcome',
+              value: payout > 0 ? `You won ${payout} coins!` : `You lost ${bet} coins.`,
+              inline: false
+            },
+            { name: 'Balance', value: `${balance}`, inline: false }
+          );
+        return message.reply({ embeds: [embed] });
       }
     } catch (err) {
       console.error('Error handling economy commands:', err);

--- a/features/slash/economy.js
+++ b/features/slash/economy.js
@@ -1,4 +1,5 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const crypto = require('crypto');
 const { getBalance, incrementBalance, getLastWorkTimestamp, setLastWorkTimestamp } = require('../../database');
 
 const COOLDOWN_MS = 60 * 60 * 1000;
@@ -12,6 +13,13 @@ async function registerSlash(client) {
     .setName('work')
     .setDescription('Work to earn a random amount once per hour.');
 
+  const slots = new SlashCommandBuilder()
+    .setName('slots')
+    .setDescription('Bet on a slot machine to win coins.')
+    .addIntegerOption((option) =>
+      option.setName('bet').setDescription('Amount to bet').setRequired(true)
+    );
+
   if (client.commands) {
     client.commands.set('/balance', {
       description: '`/balance` - Display your current balance.',
@@ -20,6 +28,11 @@ async function registerSlash(client) {
     });
     client.commands.set('/work', {
       description: '`/work` - Work to earn a random amount once per hour.',
+      category: 'Economy',
+      adminOnly: false
+    });
+    client.commands.set('/slots <bet>', {
+      description: '`/slots <bet>` - Bet on a slot machine to win coins.',
       category: 'Economy',
       adminOnly: false
     });
@@ -45,13 +58,57 @@ async function registerSlash(client) {
         const bal = await incrementBalance(interaction.guildId, interaction.user.id, amount);
         await setLastWorkTimestamp(interaction.guildId, interaction.user.id);
         await interaction.reply(`You earned ${amount} coins. Your balance is now ${bal}.`);
+      } else if (interaction.commandName === 'slots') {
+        const bet = interaction.options.getInteger('bet', true);
+        if (bet <= 0) {
+          return interaction.reply({ content: 'Please provide a valid bet amount.', ephemeral: true });
+        }
+        const current = await getBalance(interaction.guildId, interaction.user.id);
+        if (current < bet) {
+          return interaction.reply({ content: 'You do not have enough coins for that bet.', ephemeral: true });
+        }
+
+        await incrementBalance(interaction.guildId, interaction.user.id, -bet);
+
+        const symbols = ['🍒', '🍋', '🍊', '🍇', '⭐'];
+        const spin = [
+          symbols[crypto.randomInt(symbols.length)],
+          symbols[crypto.randomInt(symbols.length)],
+          symbols[crypto.randomInt(symbols.length)]
+        ];
+
+        let payout = 0;
+        if (spin[0] === spin[1] && spin[1] === spin[2]) {
+          payout = bet * 10;
+        } else if (spin[0] === spin[1] || spin[0] === spin[2] || spin[1] === spin[2]) {
+          payout = bet * 2;
+        }
+
+        if (payout > 0) {
+          await incrementBalance(interaction.guildId, interaction.user.id, payout);
+        }
+        const bal = await getBalance(interaction.guildId, interaction.user.id);
+
+        const embed = new EmbedBuilder()
+          .setTitle('Slots')
+          .addFields(
+            { name: 'Result', value: spin.join(' '), inline: false },
+            {
+              name: 'Outcome',
+              value: payout > 0 ? `You won ${payout} coins!` : `You lost ${bet} coins.`,
+              inline: false
+            },
+            { name: 'Balance', value: `${bal}`, inline: false }
+          );
+
+        await interaction.reply({ embeds: [embed] });
       }
     } catch (err) {
       console.error('Error handling economy slash commands:', err);
     }
   });
 
-  return [balance.toJSON(), work.toJSON()];
+  return [balance.toJSON(), work.toJSON(), slots.toJSON()];
 }
 
 module.exports = { registerSlash };


### PR DESCRIPTION
## Summary
- add slot machine game to economy prefix and slash commands
- update balances based on bet and payout

## Testing
- `npm test`
- `node --check features/prefix/economy.js && node --check features/slash/economy.js`


------
https://chatgpt.com/codex/tasks/task_e_6894eec6e590832e8354654fccce1693