### PR TITLE
feat: add custom command system

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It supports legacy prefix commands (`!`) and modern slash commands (`/`), all au
 - **Modmail** – DM-based support tickets with claim/unclaim/close workflow and transcript retrieval.
 - **Anti‑Raid** – Join/message spike detection, link whitelist, verification challenges, shadow mutes, quarantines, and optional lockdowns.
 - **Logging** – Moderation actions, reputation transactions, modmail events, and anti‑raid summaries can all be sent to a chosen channel.
+- **Custom Commands** – Administrators can create prefix or slash commands with dynamic responses and optional role restrictions.
 
 ## Installation
 
@@ -82,6 +83,20 @@ Formats: `YYYY-MM-DD`, `MM/DD`, `DD/MM`, `DD.MM.YYYY`.
 - `!reputation [@User]` / `/reputation [@User]`
 
 Award reputation once per day per recipient. Badges unlock at 10 (Bronze), 50 (Silver), and 100 (Gold) points.
+
+### Custom Commands
+
+- `!custom add prefix greet Hello {{user}}` – creates `!greet` responding with the user mention.
+- `/custom add type:slash name:greet response:"Hello {{user}}"` – creates `/greet` with the same reply.
+- Use `edit`, `remove`, and `list` subcommands to manage entries.
+
+Placeholders:
+
+- `{{user}}` – mentions the user invoking the command.
+- `{{channel}}` – mentions the current channel.
+- `{{guild}}` – inserts the server name.
+
+Mention roles (prefix) or supply role options (slash) during `add`/`edit` to restrict usage.
 
 ## Data Storage
 

--- a/bot.js
+++ b/bot.js
@@ -1,8 +1,17 @@
 require('dotenv').config();
-const { Client, GatewayIntentBits, Partials, REST, Routes } = require('discord.js');
+const {
+  Client,
+  GatewayIntentBits,
+  Partials,
+  REST,
+  Routes,
+  PermissionsBitField
+} = require('discord.js');
 const fs = require('fs');
 const path = require('path');
+const mongoose = require('mongoose');
 const db = require('./database');
+const CustomCommand = require('./database/customCommands');
 
 // Global error handlers to avoid silent crashes
 process.on('unhandledRejection', err => console.error('Unhandled promise rejection:', err));
@@ -32,6 +41,7 @@ if (fs.existsSync(slashPath)) {
 }
 // Shared command map for help text
 const commands = new Map();
+const customCommandsCache = new Map();
 
 // Create Discord client with desired intents
 // Include DM intents and partials so features like modmail work in DMs
@@ -59,6 +69,7 @@ client.prefixFeatures = prefixFeatures;
 client.slashFeatures = slashFeatures;
 client.features = prefixFeatures;
 client.commands = commands;
+client.customCommandsCache = customCommandsCache;
 
 // Allow each feature to register itself
 for (const feature of Object.values(prefixFeatures)) {
@@ -66,6 +77,83 @@ for (const feature of Object.values(prefixFeatures)) {
     feature.register(client, commands);
   }
 }
+
+function hasRequiredRoles(member, roles = []) {
+  if (!roles.length) return true;
+  return roles.some((id) => member.roles.cache.has(id));
+}
+
+function applyPlaceholders(text, { message, interaction }) {
+  return text.replace(/{{(user|channel|guild)}}/g, (_, token) => {
+    switch (token) {
+      case 'user':
+        return message ? message.author.toString() : interaction.user.toString();
+      case 'channel':
+        return message
+          ? message.channel.toString()
+          : interaction.channel.toString();
+      case 'guild':
+        return message ? message.guild.name : interaction.guild.name;
+      default:
+        return '';
+    }
+  });
+}
+
+async function loadCustomCommands() {
+  const docs = await CustomCommand.find({});
+  for (const doc of docs) {
+    const key = doc.type === 'prefix' ? '!' : '/';
+    if (!customCommandsCache.has(doc.guildId)) {
+      customCommandsCache.set(doc.guildId, {
+        prefix: new Map(),
+        slash: new Map()
+      });
+    }
+    const guildCache = customCommandsCache.get(doc.guildId);
+    guildCache[doc.type].set(doc.name, doc);
+    commands.set(`${key}${doc.name}`, {
+      description: `\`${key}${doc.name}\` - Custom command.`,
+      category: 'Custom',
+      adminOnly: doc.roles && doc.roles.length > 0
+    });
+  }
+}
+
+client.on('messageCreate', async (message) => {
+  try {
+    if (message.author.bot || !message.guild) return;
+    if (!message.content.startsWith('!')) return;
+    const name = message.content.slice(1).trim().split(/\s+/)[0].toLowerCase();
+    const cache = customCommandsCache.get(message.guild.id);
+    if (!cache || !cache.prefix.has(name)) return;
+    const cmd = cache.prefix.get(name);
+    if (!hasRequiredRoles(message.member, cmd.roles)) return;
+    const response = applyPlaceholders(cmd.response, { message });
+    await message.reply(response);
+  } catch (err) {
+    console.error('Error executing custom prefix command:', err);
+  }
+});
+
+client.on('interactionCreate', async (interaction) => {
+  try {
+    if (!interaction.isChatInputCommand()) return;
+    const cache = customCommandsCache.get(interaction.guildId);
+    if (!cache || !cache.slash.has(interaction.commandName)) return;
+    const cmd = cache.slash.get(interaction.commandName);
+    if (!hasRequiredRoles(interaction.member, cmd.roles)) {
+      return interaction.reply({
+        content: 'You do not have permission to use this command.',
+        ephemeral: true
+      });
+    }
+    const response = applyPlaceholders(cmd.response, { interaction });
+    await interaction.reply(response);
+  } catch (err) {
+    console.error('Error executing custom slash command:', err);
+  }
+});
 client.once('ready', async () => {
   console.log(`Logged in as ${client.user.tag}`);
 
@@ -101,6 +189,19 @@ client.once('ready', async () => {
   } catch (err) {
     console.error('Failed to register application commands:', err);
   }
+
+  // Register existing custom slash commands for their guilds
+  for (const [gid, cache] of customCommandsCache.entries()) {
+    const guild = client.guilds.cache.get(gid);
+    if (!guild) continue;
+    for (const [name] of cache.slash) {
+      try {
+        await guild.commands.create({ name, description: 'Custom command' });
+      } catch (err) {
+        console.error('Failed to register custom slash command:', err);
+      }
+    }
+  }
 });
 
 async function start() {
@@ -111,6 +212,10 @@ async function start() {
 
   try {
     await db.init();
+    await mongoose.connect(process.env.MONGODB_URI, {
+      dbName: process.env.MONGODB_DB
+    });
+    await loadCustomCommands();
   } catch (err) {
     console.error('Failed to initialize database:', err);
     throw err;

--- a/database/customCommands.js
+++ b/database/customCommands.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const customCommandSchema = new mongoose.Schema({
+  guildId: { type: String, required: true },
+  name: { type: String, required: true },
+  type: { type: String, enum: ['prefix', 'slash'], default: 'prefix' },
+  response: { type: String, required: true },
+  placeholders: [{ type: String }],
+  roles: [{ type: String }]
+});
+
+customCommandSchema.index({ guildId: 1, name: 1, type: 1 }, { unique: true });
+
+module.exports = mongoose.model('CustomCommand', customCommandSchema);

--- a/features/prefix/customCommands.js
+++ b/features/prefix/customCommands.js
@@ -1,0 +1,109 @@
+const { PermissionsBitField } = require('discord.js');
+const CustomCommand = require('../../database/customCommands');
+
+function register(client, commands) {
+  commands.set('!custom', {
+    description: '`!custom add|edit|remove|list` - Manage custom commands.',
+    category: 'Admin',
+    adminOnly: true
+  });
+
+  client.on('messageCreate', async (message) => {
+    try {
+      if (message.author.bot) return;
+      if (!message.content.startsWith('!custom')) return;
+      if (!message.member.permissions.has(PermissionsBitField.Flags.Administrator)) {
+        return message.reply('You do not have permission to use this command.');
+      }
+
+      const args = message.content.trim().split(/\s+/).slice(1);
+      const sub = args.shift()?.toLowerCase();
+      const guildId = message.guild.id;
+
+      if (sub === 'add' || sub === 'edit') {
+        const type = args.shift();
+        const name = args.shift();
+        const response = args.join(' ').replace(/<@&\d+>/g, '').trim();
+        if (!type || !['prefix', 'slash'].includes(type) || !name || !response) {
+          return message.reply('Usage: `!custom add|edit <prefix|slash> <name> <response> [@roles]`');
+        }
+        const roles = [...message.mentions.roles.keys()];
+        const placeholders = Array.from(
+          new Set(response.match(/{{(.*?)}}/g)?.map((s) => s.slice(2, -2)) || [])
+        );
+        const data = {
+          guildId,
+          type,
+          name: name.toLowerCase(),
+          response,
+          roles,
+          placeholders
+        };
+        await CustomCommand.findOneAndUpdate(
+          { guildId, name: data.name, type },
+          data,
+          { upsert: true }
+        );
+        if (!client.customCommandsCache.has(guildId)) {
+          client.customCommandsCache.set(guildId, { prefix: new Map(), slash: new Map() });
+        }
+        const cache = client.customCommandsCache.get(guildId);
+        cache[type].set(data.name, data);
+        const key = (type === 'prefix' ? '!' : '/') + data.name;
+        client.commands.set(key, {
+          description: `\`${key}\` - Custom command.`,
+          category: 'Custom',
+          adminOnly: roles.length > 0
+        });
+        if (type === 'slash') {
+          try {
+            await message.guild.commands.create({ name: data.name, description: 'Custom command' });
+          } catch (err) {
+            console.error('Failed to register slash command:', err);
+          }
+        }
+        return message.reply(`Custom command \`${name}\` saved.`);
+      }
+
+      if (sub === 'remove') {
+        const type = args.shift();
+        const name = args.shift();
+        if (!type || !['prefix', 'slash'].includes(type) || !name) {
+          return message.reply('Usage: `!custom remove <prefix|slash> <name>`');
+        }
+        await CustomCommand.deleteOne({ guildId, type, name: name.toLowerCase() });
+        const cache = client.customCommandsCache.get(guildId);
+        if (cache) cache[type].delete(name.toLowerCase());
+        const key = (type === 'prefix' ? '!' : '/') + name.toLowerCase();
+        client.commands.delete(key);
+        if (type === 'slash') {
+          try {
+            const cmd = await message.guild.commands.fetch();
+            const target = cmd.find((c) => c.name === name.toLowerCase());
+            if (target) await message.guild.commands.delete(target.id);
+          } catch (err) {
+            console.error('Failed to remove slash command:', err);
+          }
+        }
+        return message.reply(`Custom command \`${name}\` removed.`);
+      }
+
+      if (sub === 'list') {
+        const cache = client.customCommandsCache.get(guildId);
+        if (!cache) return message.reply('No custom commands.');
+        const prefix = [...cache.prefix.keys()].map((n) => `\`!${n}\``);
+        const slash = [...cache.slash.keys()].map((n) => `\`/${n}\``);
+        const lines = [];
+        if (prefix.length) lines.push('Prefix: ' + prefix.join(', '));
+        if (slash.length) lines.push('Slash: ' + slash.join(', '));
+        return message.reply(lines.join('\n') || 'No custom commands.');
+      }
+
+      return message.reply('Usage: `!custom add|edit|remove|list`');
+    } catch (err) {
+      console.error('Error handling custom command admin:', err);
+    }
+  });
+}
+
+module.exports = { register };

--- a/features/slash/customCommands.js
+++ b/features/slash/customCommands.js
@@ -1,0 +1,220 @@
+const {
+  SlashCommandBuilder,
+  PermissionsBitField
+} = require('discord.js');
+const CustomCommand = require('../../database/customCommands');
+
+async function registerSlash(client) {
+  const data = new SlashCommandBuilder()
+    .setName('custom')
+    .setDescription('Manage custom commands')
+    .setDefaultMemberPermissions(PermissionsBitField.Flags.Administrator)
+    .addSubcommand((sub) =>
+      sub
+        .setName('add')
+        .setDescription('Add a custom command')
+        .addStringOption((opt) =>
+          opt
+            .setName('type')
+            .setDescription('prefix or slash')
+            .setRequired(true)
+            .addChoices(
+              { name: 'prefix', value: 'prefix' },
+              { name: 'slash', value: 'slash' }
+            )
+        )
+        .addStringOption((opt) =>
+          opt.setName('name').setDescription('Command name').setRequired(true)
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName('response')
+            .setDescription('Response text')
+            .setRequired(true)
+        )
+        .addRoleOption((opt) =>
+          opt
+            .setName('role1')
+            .setDescription('Role required')
+            .setRequired(false)
+        )
+        .addRoleOption((opt) =>
+          opt
+            .setName('role2')
+            .setDescription('Additional role')
+            .setRequired(false)
+        )
+        .addRoleOption((opt) =>
+          opt
+            .setName('role3')
+            .setDescription('Additional role')
+            .setRequired(false)
+        )
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('edit')
+        .setDescription('Edit a custom command')
+        .addStringOption((opt) =>
+          opt
+            .setName('type')
+            .setDescription('prefix or slash')
+            .setRequired(true)
+            .addChoices(
+              { name: 'prefix', value: 'prefix' },
+              { name: 'slash', value: 'slash' }
+            )
+        )
+        .addStringOption((opt) =>
+          opt.setName('name').setDescription('Command name').setRequired(true)
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName('response')
+            .setDescription('Response text')
+            .setRequired(true)
+        )
+        .addRoleOption((opt) =>
+          opt
+            .setName('role1')
+            .setDescription('Role required')
+            .setRequired(false)
+        )
+        .addRoleOption((opt) =>
+          opt
+            .setName('role2')
+            .setDescription('Additional role')
+            .setRequired(false)
+        )
+        .addRoleOption((opt) =>
+          opt
+            .setName('role3')
+            .setDescription('Additional role')
+            .setRequired(false)
+        )
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('remove')
+        .setDescription('Remove a custom command')
+        .addStringOption((opt) =>
+          opt
+            .setName('type')
+            .setDescription('prefix or slash')
+            .setRequired(true)
+            .addChoices(
+              { name: 'prefix', value: 'prefix' },
+              { name: 'slash', value: 'slash' }
+            )
+        )
+        .addStringOption((opt) =>
+          opt.setName('name').setDescription('Command name').setRequired(true)
+        )
+    )
+    .addSubcommand((sub) =>
+      sub.setName('list').setDescription('List custom commands')
+    );
+
+  if (client.commands) {
+    client.commands.set('/custom', {
+      description: '`/custom add|edit|remove|list` - Manage custom commands.',
+      category: 'Admin',
+      adminOnly: true
+    });
+  }
+
+  client.on('interactionCreate', async (interaction) => {
+    try {
+      if (!interaction.isChatInputCommand()) return;
+      if (interaction.commandName !== 'custom') return;
+      if (!interaction.memberPermissions.has(PermissionsBitField.Flags.Administrator)) {
+        return interaction.reply({
+          content: 'You do not have permission to use this command.',
+          ephemeral: true
+        });
+      }
+      const sub = interaction.options.getSubcommand();
+      const guildId = interaction.guildId;
+      if (sub === 'add' || sub === 'edit') {
+        const type = interaction.options.getString('type');
+        const name = interaction.options.getString('name');
+        const response = interaction.options.getString('response');
+        const roles = ['role1', 'role2', 'role3']
+          .map((r) => interaction.options.getRole(r)?.id)
+          .filter(Boolean);
+        const placeholders = Array.from(
+          new Set(response.match(/{{(.*?)}}/g)?.map((s) => s.slice(2, -2)) || [])
+        );
+        const data = {
+          guildId,
+          type,
+          name: name.toLowerCase(),
+          response,
+          roles,
+          placeholders
+        };
+        await CustomCommand.findOneAndUpdate(
+          { guildId, name: data.name, type },
+          data,
+          { upsert: true }
+        );
+        if (!client.customCommandsCache.has(guildId)) {
+          client.customCommandsCache.set(guildId, { prefix: new Map(), slash: new Map() });
+        }
+        const cache = client.customCommandsCache.get(guildId);
+        cache[type].set(data.name, data);
+        const key = (type === 'prefix' ? '!' : '/') + data.name;
+        client.commands.set(key, {
+          description: `\`${key}\` - Custom command.`,
+          category: 'Custom',
+          adminOnly: roles.length > 0
+        });
+        if (type === 'slash') {
+          try {
+            await interaction.guild.commands.create({ name: data.name, description: 'Custom command' });
+          } catch (err) {
+            console.error('Failed to register slash command:', err);
+          }
+        }
+        return interaction.reply({ content: `Custom command \`${name}\` saved.`, ephemeral: true });
+      }
+      if (sub === 'remove') {
+        const type = interaction.options.getString('type');
+        const name = interaction.options.getString('name');
+        await CustomCommand.deleteOne({ guildId, type, name: name.toLowerCase() });
+        const cache = client.customCommandsCache.get(guildId);
+        if (cache) cache[type].delete(name.toLowerCase());
+        const key = (type === 'prefix' ? '!' : '/') + name.toLowerCase();
+        client.commands.delete(key);
+        if (type === 'slash') {
+          try {
+            const cmds = await interaction.guild.commands.fetch();
+            const target = cmds.find((c) => c.name === name.toLowerCase());
+            if (target) await interaction.guild.commands.delete(target.id);
+          } catch (err) {
+            console.error('Failed to remove slash command:', err);
+          }
+        }
+        return interaction.reply({ content: `Custom command \`${name}\` removed.`, ephemeral: true });
+      }
+      if (sub === 'list') {
+        const cache = client.customCommandsCache.get(guildId);
+        if (!cache)
+          return interaction.reply({ content: 'No custom commands.', ephemeral: true });
+        const prefix = [...cache.prefix.keys()].map((n) => `\`!${n}\``);
+        const slash = [...cache.slash.keys()].map((n) => `\`/${n}\``);
+        const lines = [];
+        if (prefix.length) lines.push('Prefix: ' + prefix.join(', '));
+        if (slash.length) lines.push('Slash: ' + slash.join(', '));
+        return interaction.reply({ content: lines.join('\n') || 'No custom commands.', ephemeral: true });
+      }
+    } catch (err) {
+      console.error('Error handling /custom command:', err);
+    }
+  });
+
+  // only `/custom` is registered here; actual custom commands are registered in bot.js
+  return [data.toJSON()];
+}
+
+module.exports = { registerSlash };


### PR DESCRIPTION
## Summary
- store custom command metadata in MongoDB via mongoose
- add prefix and slash admin interfaces to manage custom commands
- resolve custom commands and placeholders from a cache at runtime

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e28afcf58832eb4fe28a050411d96